### PR TITLE
Docker launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,26 +6,24 @@ Gemini is an is an automatic random testing tool for Scylla.
 
 To run Gemini, you need two clusters: an oracle cluster and a test cluster. The tool assumes that the oracle cluster is behaving correctly and compares the behavior of the test cluster to it.
 
-To start Cassandra as the oracle cluster, type:
+For development, install [docker-compose](https://docs.docker.com/compose/) for your platform.
+
+To start both clusters, type:
 
 ```sh
-docker run --name gemini-oracle -d cassandra
-```
-
-Alternatively, to start Scylla as the oracle cluster, type:
-
-```sh
-docker run --name gemini-oracle -d scylladb/scylla --smp 1 --memory 1G
-```
-
-For test cluster, you can, for example, run upstream Scylla:
-
-```sh
-docker run --name gemini-test -d scylladb/scylla --smp 1 --memory 1G
+docker-compose -f scripts/docker-compose.yml up -d
 ```
 
 You can now run Gemini against the oracle and test clusters as follows:
 
 ```sh
-gemini --test-cluster=$(docker inspect --format='{{ .NetworkSettings.IPAddress }}' gemini-test) --oracle-cluster=$(docker inspect --format='{{ .NetworkSettings.IPAddress }}' gemini-oracle)
+gemini \\
+--test-cluster=$(docker inspect --format='{{ .NetworkSettings.Networks.gemini.IPAddress }}' gemini-test) \\
+--oracle-cluster=$(docker inspect --format='{{ .NetworkSettings.Networks.gemini.IPAddress }}' gemini-oracle)
+```
+
+Alternatively, to start the clusters and run gemini in one go, type:
+
+```sh
+./scripts/gemini-launcher
 ```

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.5'
+
+networks:
+  gemini:
+    name: gemini
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.100.0/24
+
+services:
+  gemini-oracle:
+    image: cassandra:3.11.3
+    container_name: gemini-oracle
+    restart: always
+    networks:
+      gemini:
+
+  gemini-test:
+    image: scylladb/scylla:3.0.2
+    container_name: gemini-test
+    command: --smp 1 --memory 128M --api-address 0.0.0.0
+    networks:
+      gemini:

--- a/scripts/gemini-launcher
+++ b/scripts/gemini-launcher
@@ -4,31 +4,20 @@ ORACLE_NAME=gemini-oracle
 TEST_NAME=gemini-test
 GEMINI_CMD=/tmp/gemini
 
-if [[ ! "$(docker ps -q -f name=${ORACLE_NAME})" ]]; then
-    if [[ "$(docker ps -aq -f status=exited -f name=${ORACLE_NAME})" ]]; then
-        # cleanup
-        docker rm ${ORACLE_NAME}
-    fi
-    # gemini-launcher your container
-    docker run --name ${ORACLE_NAME} -d cassandra:3.11.3
-fi
+docker-compose -f scripts/docker-compose.yml up -d
 
-if [[ ! "$(docker ps -q -f name=${TEST_NAME})" ]]; then
-    if [[ "$(docker ps -aq -f status=exited -f name=${TEST_NAME})" ]]; then
-        # cleanup
-        docker rm ${TEST_NAME}
-    fi
-    # gemini-launcher your container
-    docker run --name ${TEST_NAME} -d scylladb/scylla:3.0.2 --smp 1 --memory 128M
-fi
-
-sleep 30
+ORACLE_IP=$(docker inspect --format='{{ .NetworkSettings.Networks.gemini.IPAddress }}' ${ORACLE_NAME})
+TEST_IP=$(docker inspect --format='{{ .NetworkSettings.Networks.gemini.IPAddress }}' ${TEST_NAME})
 
 GOBIN="$(dirname ${GEMINI_CMD})" go install ./...
+
+echo "Waiting for ${ORACLE_NAME} to start"
+until docker logs ${ORACLE_NAME} | grep "Starting listening for CQL clients" > /dev/null; do sleep 2; done
+echo "Waiting for ${TEST_NAME} to start"
+until docker logs ${TEST_NAME} | grep "Starting listening for CQL clients" > /dev/null; do sleep 2; done
 
 $GEMINI_CMD \
 	--max-tests=100000000 \
 	--fail-fast \
-	--test-cluster=$(docker inspect --format='{{ .NetworkSettings.IPAddress }}' $TEST_NAME) \
-	--oracle-cluster=$(docker inspect --format='{{ .NetworkSettings.IPAddress }}' $ORACLE_NAME)
-
+	--test-cluster=${TEST_IP} \
+	--oracle-cluster=${ORACLE_IP}


### PR DESCRIPTION
This adds a `scripts/run` script for launching Gemini against Apache Cassandra as the test oracle and Scylla as the system under test with Docker.

Fixes #4.