### PR TITLE
gemini-launcher: Let user pass command line arguments

### DIFF
--- a/scripts/gemini-launcher
+++ b/scripts/gemini-launcher
@@ -20,4 +20,5 @@ $GEMINI_CMD \
 	--max-tests=100000000 \
 	--fail-fast \
 	--test-cluster=${TEST_IP} \
-	--oracle-cluster=${ORACLE_IP}
+	--oracle-cluster=${ORACLE_IP} \
+	"$@"


### PR DESCRIPTION
The 'gemini' tool has bunch of command line options that the user can
specify. Allow users to do that with 'gemini-launcher' script too.