### PR TITLE
Start a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+- Launcher script (`scripts/gemini-launcher`) that starts an Apache Cassandra
+  node as the test oracle and a Scylla node as the system under test using
+  Docker.
+- Schema generation support. Gemini generates a random schema unless user
+  specifies one with the `--schema` command line option.


### PR DESCRIPTION
Let's start keeping a changelog that users can read to know the
differences between releases. The newly added CHANGELOG.md file is
supposed to follow these conventions:

https://keepachangelog.com/en/1.0.0/