### PR TITLE
gemini: duration limit

### DIFF
--- a/scripts/gemini-launcher
+++ b/scripts/gemini-launcher
@@ -22,7 +22,7 @@ echo "Waiting for ${TEST_NAME} to start"
 until docker logs ${TEST_NAME} | grep "Starting listening for CQL clients" > /dev/null; do sleep 2; done
 
 $GEMINI_CMD \
-	--max-tests=100000000 \
+	--duration=10m \
 	--fail-fast \
 	--test-cluster=${TEST_IP} \
 	--oracle-cluster=${ORACLE_IP} \


### PR DESCRIPTION
A command line argument called 'duration' is added
which controls the maximum program running time.
The 'max-tests' cli argument is now removed in favor
of time based run duration.

Fixes: #10 