### PR TITLE
schema: Restrict partition key type to int

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -88,7 +88,7 @@ func GenSchema() *Schema {
 	var partitionKeys []ColumnDef
 	numPartitionKeys := rand.Intn(MaxPartitionKeys-1) + 1
 	for i := 0; i < numPartitionKeys; i++ {
-		partitionKeys = append(partitionKeys, ColumnDef{Name: genColumnName("pk", i), Type: genColumnType()})
+		partitionKeys = append(partitionKeys, ColumnDef{Name: genColumnName("pk", i), Type: "int"})
 	}
 	var clusteringKeys []ColumnDef
 	numClusteringKeys := rand.Intn(MaxClusteringKeys)


### PR DESCRIPTION
We partition keyspace between different concurrent goroutines to ensure
there are no concurrent writes when we read. However, as pointed out by
Henrik, the partition keys are mapped to tokens and there are no
guarantees that the mapping respects the partitioning for arbitrary
types, which can lead to a concurrent write on the partition we are
reading from.

Threfore, restrict partition key type to int, which fixes
the Gemini complaint that oracle and test cluster results sets have
different sizes.