### PR TITLE
gemini-launcher: Stop execution on error

### DIFF
--- a/scripts/gemini-launcher
+++ b/scripts/gemini-launcher
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 function quit () {
     echo $2
     exit $1


### PR DESCRIPTION
If one of the commands in gemini-launcher fails, stop execution.