### PR TITLE
schema: skip secondary indexes for durations

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -392,6 +392,9 @@ func GenSchema() *Schema {
 	if numColumns > 0 {
 		numIndexes := rand.Intn(numColumns)
 		for i := 0; i < numIndexes; i++ {
+			if columns[i].Type == TYPE_DURATION {
+				continue
+			}
 			indexes = append(indexes, IndexDef{Name: genIndexName("col", i), Column: columns[i]})
 		}
 	}


### PR DESCRIPTION
We simply skip schema index generation for durations and
the indexes will not be used for either creation or selection.

Fixes: #66 