### PR TITLE
schema: index definition JSON cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- JSON schema definition file has simpler index definition.
+
 ## [0.9.2] - 2019-04-18
 
 - Support for User Defined Types (UDT) added for simple columns.

--- a/cmd/gemini/schema.json
+++ b/cmd/gemini/schema.json
@@ -1,77 +1,96 @@
 {
-    "keyspace": {
-        "name": "gemini"
-    },
-    "tables": [
+  "keyspace": {
+    "name": "ks1"
+  },
+  "tables": [
+    {
+      "name": "table1",
+      "partition_keys": [
         {
-            "name": "data1",
-            "partition_keys": [
-                {
-                    "name": "pk",
-                    "type": "int"
-                }
-            ],
-            "clustering_keys": [
-                {
-                    "name": "ck",
-                    "type": "int"
-                }
-            ],
-            "columns": [
-                {
-                    "name": "n",
-                    "type": "uuid"
-                },
-                {
-                    "name": "t",
-                    "type": "timestamp"
-                }
-            ]
+          "name": "pk0",
+          "type": "int"
+        }
+      ],
+      "clustering_keys": [
+        {
+          "name": "ck0",
+          "type": "date"
         },
         {
-            "name": "data2",
-            "partition_keys": [
-                {
-                    "name": "pk1",
-                    "type": "int"
-                },
-                {
-                    "name": "pk2",
-                    "type": "int"
-                }
-            ],
-            "clustering_keys": [
-                {
-                    "name": "ck1",
-                    "type": "int"
-                },
-                {
-                    "name": "ck2",
-                    "type": "int"
-                }
-            ],
-            "columns": [
-                {
-                    "name": "a",
-                    "type": "bigint"
-                },
-                {
-                    "name": "b",
-                    "type": "blob"
-                },
-                {
-                    "name": "c",
-                    "type": "text"
-                },
-                {
-                    "name": "d",
-                    "type": "date"
-                },
-                {
-                    "name": "e",
-                    "type": "varchar"
-                }
-            ]
+          "name": "ck1",
+          "type": "varint"
+        },
+        {
+          "name": "ck2",
+          "type": "varchar"
         }
-    ]
+      ],
+      "columns": [
+        {
+          "name": "col0",
+          "type": {
+            "types": {
+              "udt_672245080_0": "ascii",
+              "udt_672245080_1": "boolean",
+              "udt_672245080_2": "bigint",
+              "udt_672245080_3": "blob"
+            },
+            "type_name": "udt_672245080",
+            "frozen": true
+          }
+        },
+        {
+          "name": "col1",
+          "type": "timestamp"
+        },
+        {
+          "name": "col2",
+          "type": "decimal"
+        },
+        {
+          "name": "col3",
+          "type": "uuid"
+        },
+        {
+          "name": "col4",
+          "type": {
+            "key_type": "boolean",
+            "value_type": "duration",
+            "frozen": false
+          }
+        },
+        {
+          "name": "col5",
+          "type": {
+            "types": [
+              "varchar",
+              "smallint"
+            ],
+            "frozen": false
+          }
+        }
+      ],
+      "indexes": [
+        {
+          "name": "col0_idx",
+          "column": "col0"
+        },
+        {
+          "name": "col1_idx",
+          "column": "col1"
+        },
+        {
+          "name": "col2_idx",
+          "column": "col2"
+        },
+        {
+          "name": "col3_idx",
+          "column": "col3"
+        }
+      ],
+      "known_issues": {
+        "https://github.com/scylladb/scylla/issues/3708": true
+      }
+    }
+  ]
 }

--- a/types.go
+++ b/types.go
@@ -196,8 +196,8 @@ func (st SimpleType) GenValueRange(p *PartitionRange) ([]interface{}, []interfac
 }
 
 type TupleType struct {
-	Types  []SimpleType
-	Frozen bool
+	Types  []SimpleType `json:"types"`
+	Frozen bool         `json:"frozen"`
 }
 
 func (tt TupleType) Name() string {
@@ -252,9 +252,9 @@ func (tt TupleType) GenValueRange(p *PartitionRange) ([]interface{}, []interface
 }
 
 type UDTType struct {
-	Types    map[string]SimpleType
-	TypeName string
-	Frozen   bool
+	Types    map[string]SimpleType `json:"types"`
+	TypeName string                `json:"type_name"`
+	Frozen   bool                  `json:"frozen"`
 }
 
 func (tt UDTType) Name() string {
@@ -301,8 +301,8 @@ func (tt UDTType) GenValueRange(p *PartitionRange) ([]interface{}, []interface{}
 }
 
 type SetType struct {
-	Type   SimpleType
-	Frozen bool
+	Type   SimpleType `json:"type"`
+	Frozen bool       `json:"frozen"`
 }
 
 func (ct SetType) Name() string {
@@ -367,9 +367,9 @@ func (lt ListType) CQLDef() string {
 }
 
 type MapType struct {
-	KeyType   SimpleType
-	ValueType SimpleType
-	Frozen    bool
+	KeyType   SimpleType `json:"key_type"`
+	ValueType SimpleType `json:"value_type"`
+	Frozen    bool       `json:"frozen"`
 }
 
 func (mt MapType) Name() string {


### PR DESCRIPTION
Instead of reproducing the entire types for the index in question
we simply store a reference to the column name.

Fixes: #76 