### PR TITLE
gemini: Accept semicolon separated hosts for clusters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Gemini now accepts a list of node host names or IPs for the test
+  and Oracle clusters.
+
 ## [1.0.0] - 2019-05-06
 
 - Gemini version is now available in the resulting output.

--- a/cmd/gemini/root.go
+++ b/cmd/gemini/root.go
@@ -21,8 +21,8 @@ import (
 )
 
 var (
-	testClusterHost   string
-	oracleClusterHost string
+	testClusterHost   []string
+	oracleClusterHost []string
 	schemaFile        string
 	outFileArg        string
 	concurrency       int
@@ -349,9 +349,9 @@ func Execute() {
 func init() {
 
 	rootCmd.Version = version + ", commit " + commit + ", date " + date
-	rootCmd.Flags().StringVarP(&testClusterHost, "test-cluster", "t", "", "Host name of the test cluster that is system under test")
+	rootCmd.Flags().StringSliceVarP(&testClusterHost, "test-cluster", "t", []string{}, "Host names or IPs of the test cluster that is system under test")
 	rootCmd.MarkFlagRequired("test-cluster")
-	rootCmd.Flags().StringVarP(&oracleClusterHost, "oracle-cluster", "o", "", "Host name of the oracle cluster that provides correct answers")
+	rootCmd.Flags().StringSliceVarP(&oracleClusterHost, "oracle-cluster", "o", []string{}, "Host names or IPs of the oracle cluster that provides correct answers")
 	rootCmd.MarkFlagRequired("oracle-cluster")
 	rootCmd.Flags().StringVarP(&schemaFile, "schema", "", "", "Schema JSON config file")
 	rootCmd.Flags().StringVarP(&mode, "mode", "m", mixedMode, "Query operation mode. Mode options: write, read, mixed (default)")

--- a/session.go
+++ b/session.go
@@ -26,15 +26,15 @@ type JobError struct {
 	Query   string `json:"query"`
 }
 
-func NewSession(testClusterHost string, oracleClusterHost string) *Session {
-	testCluster := gocql.NewCluster(testClusterHost)
+func NewSession(testClusterHost []string, oracleClusterHost []string) *Session {
+	testCluster := gocql.NewCluster(testClusterHost...)
 	testCluster.Timeout = 5 * time.Second
 	testSession, err := testCluster.CreateSession()
 	if err != nil {
 		panic(err)
 	}
 
-	oracleCluster := gocql.NewCluster(oracleClusterHost)
+	oracleCluster := gocql.NewCluster(oracleClusterHost...)
 	oracleCluster.Timeout = 5 * time.Second
 	oracleSession, err := oracleCluster.CreateSession()
 	if err != nil {


### PR DESCRIPTION
Bot the test anc oracle clusters can now be given a semicolon
separated list of nodes on the command line.

The previous single host/ip still works.

Fixes: #86 