### PR TITLE
gemini: ensure max pk per bucket in valid range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Gemini ensures that primary key buckets do not overflow int32.
 - Gemini now accepts a list of node host names or IPs for the test
   and Oracle clusters.
 - Default maximum primary keys increased to MAX_INT32/concurrency.

--- a/cmd/gemini/root.go
+++ b/cmd/gemini/root.go
@@ -128,7 +128,7 @@ func readSchema(confFile string) (*gemini.Schema, error) {
 }
 
 func run(cmd *cobra.Command, args []string) {
-	if pkNumberPerThread == 0 {
+	if pkNumberPerThread <= 0 || pkNumberPerThread > (math.MaxInt32/concurrency) {
 		pkNumberPerThread = math.MaxInt32 / concurrency
 	}
 	if err := printSetup(); err != nil {


### PR DESCRIPTION
Fixes: #99 