### PR TITLE
store: Fix timestamp to be same for test and oracle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix mutation timestamps to match on system under test and test oracle.
 - Gemini now tries to perform mutation on both systems regardless of
   if one of them fail.
 

--- a/store/cqlstore.go
+++ b/store/cqlstore.go
@@ -15,9 +15,10 @@ type cqlStore struct {
 	schema  *gemini.Schema
 }
 
-func (cs *cqlStore) mutate(builder qb.Builder, values ...interface{}) error {
+func (cs *cqlStore) mutate(builder qb.Builder, ts time.Time, values ...interface{}) error {
 	query, _ := builder.ToCql()
-	if err := cs.session.Query(query, values...).Exec(); err != nil {
+	var tsUsec int64 = ts.UnixNano() / 1000
+	if err := cs.session.Query(query, values...).WithTimestamp(tsUsec).Exec(); err != nil {
 		return errors.Errorf("%v [cluster = test, query = '%s']", err, query)
 	}
 	return nil

--- a/store/store.go
+++ b/store/store.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -21,7 +22,7 @@ type loader interface {
 }
 
 type storer interface {
-	mutate(qb.Builder, ...interface{}) error
+	mutate(qb.Builder, time.Time, ...interface{}) error
 }
 
 type storeLoader interface {
@@ -55,10 +56,11 @@ type delegatingStore struct {
 }
 
 func (ds delegatingStore) Mutate(builder qb.Builder, values ...interface{}) error {
-	if err := ds.testStore.mutate(builder, values...); err != nil {
+	ts := time.Now()
+	if err := ds.testStore.mutate(builder, ts, values...); err != nil {
 		return errors.Wrapf(err, "unable to apply mutations to the test store")
 	}
-	if err := ds.oracleStore.mutate(builder, values...); err != nil {
+	if err := ds.oracleStore.mutate(builder, ts, values...); err != nil {
 		return errors.Wrapf(err, "unable to apply mutations to the oracle store")
 	}
 	return nil


### PR DESCRIPTION
We already enable client-side timestamps, but since we do two separate
queries, they will be different. Let's use the WithTimestamp() API to
make sure timestamps match for both systems.