### PR TITLE
gemini: terminating properly upon an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Ensure proper termination when errors happen.
 - Fix mutation timestamps to match on system under test and test oracle.
 - Gemini now tries to perform mutation on both systems regardless of
   if one of them fail.


### PR DESCRIPTION
We ensure that we drain the remaining work after a quit signal is
detected. This ensures that no workers get blocked on trying to
send a status message after the receiving end has stopped listening.

We also send down the termination context to the driver to allow
it to abort what it is doing as fast as possible.

Fixes: #106 