### PR TITLE
Backport mutate timestamps to 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix mutation timestamps to match on system under test and test oracle.
 - Gemini now timestamps errors for easier correlation.
  
 ## [1.0.1] - 2019-05-16

--- a/session.go
+++ b/session.go
@@ -56,10 +56,12 @@ func (s *Session) Close() {
 }
 
 func (s *Session) Mutate(query string, values ...interface{}) error {
-	if err := s.testSession.Query(query, values...).Exec(); err != nil {
+	ts := time.Now()
+	var tsUsec int64 = ts.UnixNano() / 1000
+	if err := s.testSession.Query(query, values...).WithTimestamp(tsUsec).Exec(); err != nil {
 		return fmt.Errorf("%v [cluster = test, query = '%s']", err, query)
 	}
-	if err := s.oracleSession.Query(query, values...).Exec(); err != nil {
+	if err := s.oracleSession.Query(query, values...).WithTimestamp(tsUsec).Exec(); err != nil {
 		return fmt.Errorf("%v [cluster = oracle, query = '%s']", err, query)
 	}
 	return nil


### PR DESCRIPTION
This backports commit d0a8c7c80c324245b775aef6cf5c6317816ef900 ("store: Fix timestamp to be same for test and oracle") to 1.0.