### PR TITLE
Backport termination fix to 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Ensure proper termination when errors happen.
 - Fix mutation timestamps to match on system under test and test oracle.
 - Gemini now timestamps errors for easier correlation.
  


### PR DESCRIPTION
This backports commit c8b24257f0cc5407e51602d19887144c115773ef ("gemini: terminating properly upon an error") to 1.0. Also fix error handling in `Session.Check()` to match `master` to avoid crashing Gemini if result set iterator closing fails.