### PR TITLE
gemini: warmup time configurable using cli argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Prometheus metrics added that exposes internal runtime properties
   as well as counts fo CQL operations 'batch', 'delete', 'insert', 'select'
   and 'update'.
+- Warmup duration added during which only inserts are performed.
 - Generating valid single index queries when a complex primary key is used.
 - Gracefully stopping on sigint and sigterm.
 - JSON marshalling of Schema fixed. The schema input file has changed to

--- a/schema.go
+++ b/schema.go
@@ -370,7 +370,10 @@ func (s *Schema) GenDeleteRows(t *Table, p *PartitionRange) (*Stmt, error) {
 	}, nil
 }
 
-func (s *Schema) GenMutateStmt(t *Table, p *PartitionRange) (*Stmt, error) {
+func (s *Schema) GenMutateStmt(t *Table, p *PartitionRange, deletes bool) (*Stmt, error) {
+	if !deletes {
+		return s.GenInsertStmt(t, p)
+	}
 	switch n := p.Rand.Intn(1000); n {
 	case 10, 100:
 		return s.GenDeleteRows(t, p)


### PR DESCRIPTION
Gemini now has a cli argument 'warmup' which is a duration given
in a format such as '30s', '15m' or '10h'.
This time is taken from the duration time so as to make total run
time easy to set.

For example: Given a duration of 10h and a warmup of 2h there will
be an 8 hours window where validations happen after a 2 hours run
with only inserts.

Fixes: #129 