### PR TITLE
gemini: adds support for consistency levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Support for compation strategies added via a CLI argument `compaction-strategy`
+- Support for changing consistency level via a CLI argument `consistency`.
+- Support for compaction strategies added via a CLI argument `compaction-strategy`
   as a set of string values "stcs", "twcs" or "lcs" which will make Gemini choose
   the default values for the properties of the respective compaction strategies.
   Alternatively the JSON-like definition of the compaction-strategy can be supplied


### PR DESCRIPTION
A new CLI arg `consistency` is added which is then consistently
used throughout the application.

Fixes: #90 