### PR TITLE
gemini: exponential backoff retry policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Exponential backoff retry policy added with 5 retries between 1 and 10 seconds.
 - Support for changing consistency level via a CLI argument `consistency`.
 - Support for compaction strategies added via a CLI argument `compaction-strategy`
   as a set of string values "stcs", "twcs" or "lcs" which will make Gemini choose

--- a/cmd/gemini/root.go
+++ b/cmd/gemini/root.go
@@ -227,11 +227,18 @@ func run(cmd *cobra.Command, args []string) {
 }
 
 func createClusters(consistency gocql.Consistency) (*gocql.ClusterConfig, *gocql.ClusterConfig) {
+	retryPolicy := &gocql.ExponentialBackoffRetryPolicy{
+		Min:        time.Second,
+		Max:        10 * time.Second,
+		NumRetries: 5,
+	}
 	testCluster := gocql.NewCluster(testClusterHost...)
 	testCluster.Timeout = 5 * time.Second
+	testCluster.RetryPolicy = retryPolicy
 	testCluster.Consistency = consistency
 	oracleCluster := gocql.NewCluster(oracleClusterHost...)
 	oracleCluster.Timeout = 5 * time.Second
+	oracleCluster.RetryPolicy = retryPolicy
 	oracleCluster.Consistency = consistency
 	return testCluster, oracleCluster
 }


### PR DESCRIPTION
A hard coded backoff retry policy added to both clusters.
Between 1 to 10 seconds with a max of 5 retries.

Fixes: #112 