### PR TITLE
schema: ddl jobs added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- DDL statements are now emitted with low frequency if the `--cql-features` is set to at
+  least `"all"` level.
 - Data sizes are configurable though a CLI argument `--dataset-size` and the currently
   supported values are "small" and "large".
 - CLI toggle `--cql-features` added to let the user select which type of CQL features

--- a/types.go
+++ b/types.go
@@ -42,8 +42,50 @@ const (
 
 // TODO: Add support for time when gocql bug is fixed.
 var (
-	pkTypes = []SimpleType{TYPE_ASCII, TYPE_BIGINT, TYPE_BLOB, TYPE_DATE, TYPE_DECIMAL, TYPE_DOUBLE, TYPE_FLOAT, TYPE_INET, TYPE_INT, TYPE_SMALLINT, TYPE_TEXT /*TYPE_TIME,*/, TYPE_TIMESTAMP, TYPE_TIMEUUID, TYPE_TINYINT, TYPE_UUID, TYPE_VARCHAR, TYPE_VARINT}
-	types   = append(append([]SimpleType{}, pkTypes...), TYPE_BOOLEAN, TYPE_DURATION)
+	pkTypes               = []SimpleType{TYPE_ASCII, TYPE_BIGINT, TYPE_BLOB, TYPE_DATE, TYPE_DECIMAL, TYPE_DOUBLE, TYPE_FLOAT, TYPE_INET, TYPE_INT, TYPE_SMALLINT, TYPE_TEXT /*TYPE_TIME,*/, TYPE_TIMESTAMP, TYPE_TIMEUUID, TYPE_TINYINT, TYPE_UUID, TYPE_VARCHAR, TYPE_VARINT}
+	types                 = append(append([]SimpleType{}, pkTypes...), TYPE_BOOLEAN, TYPE_DURATION)
+	compatibleColumnTypes = map[SimpleType][]SimpleType{
+		TYPE_ASCII: {
+			TYPE_TEXT,
+			TYPE_BLOB,
+		},
+		TYPE_BIGINT: {
+			TYPE_BLOB,
+		},
+		TYPE_BOOLEAN: {
+			TYPE_BLOB,
+		},
+		TYPE_DECIMAL: {
+			TYPE_BLOB,
+		},
+		TYPE_FLOAT: {
+			TYPE_BLOB,
+		},
+		TYPE_INET: {
+			TYPE_BLOB,
+		},
+		TYPE_INT: {
+			TYPE_VARINT,
+			TYPE_BLOB,
+		},
+		TYPE_TIMESTAMP: {
+			TYPE_BLOB,
+		},
+		TYPE_TIMEUUID: {
+			TYPE_UUID,
+			TYPE_BLOB,
+		},
+		TYPE_UUID: {
+			TYPE_BLOB,
+		},
+		TYPE_VARCHAR: {
+			TYPE_TEXT,
+			TYPE_BLOB,
+		},
+		TYPE_VARINT: {
+			TYPE_BLOB,
+		},
+	}
 )
 
 type SimpleType string

--- a/types_test.go
+++ b/types_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"gopkg.in/inf.v0"
 )
 
@@ -293,6 +294,11 @@ func TestMarshalUnmarshal(t *testing.T) {
 		},
 	}
 
+	opts := cmp.Options{
+		cmp.AllowUnexported(Table{}),
+		cmpopts.IgnoreUnexported(Table{}),
+	}
+
 	b, err := json.MarshalIndent(s1, "  ", "  ")
 	if err != nil {
 		t.Fatalf("unable to marshal json, error=%s\n", err)
@@ -303,7 +309,7 @@ func TestMarshalUnmarshal(t *testing.T) {
 		t.Fatalf("unable to unmarshal json, error=%s\n", err)
 	}
 
-	if diff := cmp.Diff(s1, s2); diff != "" {
+	if diff := cmp.Diff(s1, s2, opts); diff != "" {
 		t.Errorf("schema not the same after marshal/unmarshal, diff=%s", diff)
 	}
 }


### PR DESCRIPTION
Mutation jobs now also emit DDL jobs to allow testing with schema
changes. Currently only colum add and drop are supported due to
https://issues.apache.org/jira/browse/CASSANDRA-12443 and the
frequency of the schema changes are not configurable.

The synchronization of the internal Table struct is handled with
explicit locking which may not be ideal but a message passing
solution would require extensive refactoring.

Fixes: #30 