### PR TITLE
gemini: partition keys can now be other than ints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Partition keys can now be any supported type.
 - The size of the partition key buffers can be configured on the commandline through
   `partition-key-buffer-size` and `partition-key-buffer-reuse-size`.
 

--- a/generator.go
+++ b/generator.go
@@ -1,8 +1,6 @@
 package gemini
 
 import (
-	"fmt"
-
 	"github.com/scylladb/gemini/murmur"
 	"golang.org/x/exp/rand"
 )
@@ -25,7 +23,7 @@ type Generators struct {
 
 type GeneratorsConfig struct {
 	Table            *Table
-	Partitions       *PartitionRangeConfig
+	Partitions       PartitionRangeConfig
 	Size             uint64
 	Seed             uint64
 	PkBufferSize     uint64
@@ -41,11 +39,12 @@ func NewGenerator(config *GeneratorsConfig) *Generators {
 		}
 	}
 	gs := &Generators{
-		generators: generators,
-		size:       config.Size,
-		table:      config.Table,
-		seed:       config.Seed,
-		done:       make(chan struct{}, 1),
+		generators:       generators,
+		size:             config.Size,
+		table:            config.Table,
+		partitionsConfig: config.Partitions,
+		seed:             config.Seed,
+		done:             make(chan struct{}, 1),
 	}
 	gs.start()
 	return gs
@@ -89,7 +88,6 @@ func sendIfPossible(values chan Value, value Value) {
 	select {
 	case values <- value:
 	default:
-		fmt.Println("Skipped returning an partition key")
 	}
 }
 

--- a/scripts/gemini-launcher
+++ b/scripts/gemini-launcher
@@ -15,6 +15,7 @@ docker-compose --log-level WARNING -f scripts/docker-compose.yml up -d
 
 ORACLE_IP=$(docker inspect --format='{{ .NetworkSettings.Networks.gemini.IPAddress }}' ${ORACLE_NAME})
 TEST_IP=$(docker inspect --format='{{ .NetworkSettings.Networks.gemini.IPAddress }}' ${TEST_NAME})
+SEED=$(date +%s%N)
 
 GOBIN="$(dirname ${GEMINI_CMD})" go install ./... || quit $? "Compilation failed"
 
@@ -26,6 +27,7 @@ until docker logs ${TEST_NAME} | grep "Starting listening for CQL clients" > /de
 $GEMINI_CMD \
 	--duration=10m \
 	--fail-fast \
+	--seed=${SEED} \
 	--dataset-size=small \
 	--test-cluster=${TEST_IP} \
 	--oracle-cluster=${ORACLE_IP} \

--- a/types.go
+++ b/types.go
@@ -609,8 +609,7 @@ func genMapType(sc *SchemaConfig) MapType {
 }
 
 func genPrimaryKeyColumnType() Type {
-	n := rand.Intn(len(pkTypes))
-	return types[n]
+	return pkTypes[rand.Intn(len(pkTypes))]
 }
 
 func genIndexName(prefix string, idx int) string {


### PR DESCRIPTION
The new partition scheme makes it possible to work with any supported
type as partition key.

Fixes: #53 