### PR TITLE
gemini: partition key generation improved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+# Unreleased
+
+- A `source` concept is used to coordinate the creation, consumption and reuse of
+  partition keys.
+- Two new CLI args are introduced to control the buffer sizes of the new and reusable
+  partition keys `partition-key-buffer-size` and `partition-key-buffer-reuse-size`.
+- The CLI arg `concurrency` now means the total number of actors per job type. 
+  You may need to scale down your settings for this argument since for example a
+  mixed mode execution will run with twice as many goroutines. Experimentation is
+  encouraged since a high number will also yield much greater throughput.
+
 ## 1.3.4
 
 - Shutdown is no longer waiting for the warmup phase to complete.

--- a/cmd/gemini/generators.go
+++ b/cmd/gemini/generators.go
@@ -1,0 +1,27 @@
+package main
+
+import "github.com/scylladb/gemini"
+
+func createGenerators(schema *gemini.Schema, schemaConfig gemini.SchemaConfig, actors uint64) []*gemini.Generators {
+	partitionRangeConfig := gemini.PartitionRangeConfig{
+		MaxBlobLength:   schemaConfig.MaxBlobLength,
+		MinBlobLength:   schemaConfig.MinBlobLength,
+		MaxStringLength: schemaConfig.MaxStringLength,
+		MinStringLength: schemaConfig.MinStringLength,
+	}
+
+	var gs []*gemini.Generators
+	for _, table := range schema.Tables {
+		gCfg := &gemini.GeneratorsConfig{
+			Table:            table,
+			Partitions:       partitionRangeConfig,
+			Size:             actors,
+			Seed:             seed,
+			PkBufferSize:     pkBufferSize,
+			PkUsedBufferSize: pkBufferReuseSize,
+		}
+		g := gemini.NewGenerator(gCfg)
+		gs = append(gs, g)
+	}
+	return gs
+}

--- a/cmd/gemini/jobs.go
+++ b/cmd/gemini/jobs.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/scylladb/gemini"
+	"github.com/scylladb/gemini/store"
+	"go.uber.org/zap"
+	"golang.org/x/exp/rand"
+)
+
+// MutationJob continuously applies mutations against the database
+// for as long as the pump is active.
+func MutationJob(ctx context.Context, pump <-chan heartBeat, wg *sync.WaitGroup, schema *gemini.Schema, schemaCfg gemini.SchemaConfig, table *gemini.Table, s store.Store, r *rand.Rand, p gemini.PartitionRangeConfig, source *gemini.Source, c chan Status, mode string, warmup time.Duration, logger *zap.Logger) {
+	defer wg.Done()
+	schemaConfig := &schemaCfg
+	logger = logger.Named("mutation_job")
+	testStatus := Status{}
+	var i int
+	for hb := range pump {
+		hb.await()
+		ind := r.Intn(1000000)
+		if ind%100000 == 0 {
+			ddl(ctx, schema, schemaConfig, table, s, r, p, &testStatus, logger)
+		} else {
+			mutation(ctx, schema, schemaConfig, table, s, r, p, source, &testStatus, true, logger)
+		}
+		if i%1000 == 0 {
+			c <- testStatus
+			testStatus = Status{}
+		}
+		if failFast && (testStatus.ReadErrors > 0 || testStatus.WriteErrors > 0) {
+			break
+		}
+		i++
+	}
+}
+
+// ValidationJob continuously applies validations against the database
+// for as long as the pump is active.
+func ValidationJob(ctx context.Context, pump <-chan heartBeat, wg *sync.WaitGroup, schema *gemini.Schema, schemaCfg gemini.SchemaConfig, table *gemini.Table, s store.Store, r *rand.Rand, p gemini.PartitionRangeConfig, source *gemini.Source, c chan Status, mode string, warmup time.Duration, logger *zap.Logger) {
+	defer wg.Done()
+	schemaConfig := &schemaCfg
+	logger = logger.Named("validation_job")
+
+	testStatus := Status{}
+	var i int
+	for hb := range pump {
+		hb.await()
+		validation(ctx, schema, schemaConfig, table, s, r, p, source, &testStatus, logger)
+		if i%1000 == 0 {
+			c <- testStatus
+			testStatus = Status{}
+		}
+		if failFast && (testStatus.ReadErrors > 0 || testStatus.WriteErrors > 0) {
+			break
+		}
+		i++
+	}
+}
+
+// WarmupJob continuously applies mutations against the database
+// for as long as the pump is active or the supplied duration expires.
+func WarmupJob(ctx context.Context, pump <-chan heartBeat, wg *sync.WaitGroup, schema *gemini.Schema, schemaCfg gemini.SchemaConfig, table *gemini.Table, s store.Store, r *rand.Rand, p gemini.PartitionRangeConfig, source *gemini.Source, c chan Status, mode string, warmup time.Duration, logger *zap.Logger) {
+	defer wg.Done()
+	schemaConfig := &schemaCfg
+	testStatus := Status{}
+	var i int
+	warmupTimer := time.NewTimer(warmup)
+	for {
+		select {
+		case _, ok := <-pump:
+			if !ok {
+				logger.Info("warmup job terminated")
+				return
+			}
+		}
+		select {
+		case <-warmupTimer.C:
+			c <- testStatus
+			return
+		default:
+			mutation(ctx, schema, schemaConfig, table, s, r, p, source, &testStatus, false, logger)
+			if i%1000 == 0 {
+				c <- testStatus
+				testStatus = Status{}
+			}
+		}
+	}
+}
+
+func job(done *sync.WaitGroup, f testJob, actors uint64, schema *gemini.Schema, schemaConfig gemini.SchemaConfig, s store.Store, pump *Pump, generators []*gemini.Generators, result chan Status, logger *zap.Logger) {
+	defer done.Done()
+	var finished sync.WaitGroup
+	finished.Add(1)
+
+	// Wait group for the worker goroutines.
+	var workers sync.WaitGroup
+	workerCtx, _ := context.WithCancel(context.Background())
+	workers.Add(len(schema.Tables) * int(actors))
+
+	partitionRangeConfig := gemini.PartitionRangeConfig{
+		MaxBlobLength:   schemaConfig.MaxBlobLength,
+		MinBlobLength:   schemaConfig.MinBlobLength,
+		MaxStringLength: schemaConfig.MaxStringLength,
+		MinStringLength: schemaConfig.MinStringLength,
+	}
+
+	for j, table := range schema.Tables {
+		for i := 0; i < int(actors); i++ {
+			r := rand.New(rand.NewSource(seed))
+			go f(workerCtx, pump.ch, &workers, schema, schemaConfig, table, s, r, partitionRangeConfig, generators[j].Get(i), result, mode, warmup, logger)
+		}
+	}
+
+	workers.Wait()
+}
+
+func ddl(ctx context.Context, schema *gemini.Schema, sc *gemini.SchemaConfig, table *gemini.Table, s store.Store, r *rand.Rand, p gemini.PartitionRangeConfig, testStatus *Status, logger *zap.Logger) {
+	if sc.CQLFeature != gemini.CQL_FEATURE_ALL {
+		logger.Debug("ddl statements disabled")
+		return
+	}
+	table.Lock()
+	defer table.Unlock()
+	ddlStmts, postStmtHook, err := schema.GenDDLStmt(table, r, p, sc)
+	if err != nil {
+		logger.Error("Failed! Mutation statement generation failed", zap.Error(err))
+		testStatus.WriteErrors++
+		return
+	}
+	if ddlStmts == nil {
+		if w := logger.Check(zap.DebugLevel, "no statement generated"); w != nil {
+			w.Write(zap.String("job", "ddl"))
+		}
+		return
+	}
+	defer postStmtHook()
+	defer func() {
+		if verbose {
+			jsonSchema, _ := json.MarshalIndent(schema, "", "    ")
+			fmt.Printf("Schema: %v\n", string(jsonSchema))
+		}
+	}()
+	for _, ddlStmt := range ddlStmts {
+		ddlQuery := ddlStmt.Query
+		if w := logger.Check(zap.DebugLevel, "ddl statement"); w != nil {
+			w.Write(zap.String("pretty_cql", ddlStmt.PrettyCQL()))
+		}
+		if err := s.Mutate(ctx, ddlQuery); err != nil {
+			e := JobError{
+				Timestamp: time.Now(),
+				Message:   "DDL failed: " + err.Error(),
+				Query:     ddlStmt.PrettyCQL(),
+			}
+			testStatus.Errors = append(testStatus.Errors, e)
+			testStatus.WriteErrors++
+		} else {
+			testStatus.WriteOps++
+		}
+	}
+}
+
+func mutation(ctx context.Context, schema *gemini.Schema, _ *gemini.SchemaConfig, table *gemini.Table, s store.Store, r *rand.Rand, p gemini.PartitionRangeConfig, source *gemini.Source, testStatus *Status, deletes bool, logger *zap.Logger) {
+	mutateStmt, err := schema.GenMutateStmt(table, source, r, p, deletes)
+	if err != nil {
+		logger.Error("Failed! Mutation statement generation failed", zap.Error(err))
+		testStatus.WriteErrors++
+		return
+	}
+	if mutateStmt == nil {
+		if w := logger.Check(zap.DebugLevel, "no statement generated"); w != nil {
+			w.Write(zap.String("job", "mutation"))
+		}
+		return
+	}
+	mutateQuery := mutateStmt.Query
+	mutateValues := mutateStmt.Values()
+	if w := logger.Check(zap.DebugLevel, "validation statement"); w != nil {
+		w.Write(zap.String("pretty_cql", mutateStmt.PrettyCQL()))
+	}
+	if err := s.Mutate(ctx, mutateQuery, mutateValues...); err != nil {
+		e := JobError{
+			Timestamp: time.Now(),
+			Message:   "Mutation failed: " + err.Error(),
+			Query:     mutateStmt.PrettyCQL(),
+		}
+		testStatus.Errors = append(testStatus.Errors, e)
+		testStatus.WriteErrors++
+	} else {
+		testStatus.WriteOps++
+	}
+}
+
+func validation(ctx context.Context, schema *gemini.Schema, _ *gemini.SchemaConfig, table *gemini.Table, s store.Store, r *rand.Rand, p gemini.PartitionRangeConfig, source *gemini.Source, testStatus *Status, logger *zap.Logger) {
+	checkStmt := schema.GenCheckStmt(table, source, r, p)
+	if checkStmt == nil {
+		if w := logger.Check(zap.DebugLevel, "no statement generated"); w != nil {
+			w.Write(zap.String("job", "validation"))
+		}
+		return
+	}
+	checkQuery := checkStmt.Query
+	checkValues := checkStmt.Values()
+	if w := logger.Check(zap.DebugLevel, "validation statement"); w != nil {
+		w.Write(zap.String("pretty_cql", checkStmt.PrettyCQL()))
+	}
+	if err := s.Check(ctx, table, checkQuery, checkValues...); err != nil {
+		// De-duplication needed?
+		e := JobError{
+			Timestamp: time.Now(),
+			Message:   "Validation failed: " + err.Error(),
+			Query:     checkStmt.PrettyCQL(),
+		}
+		testStatus.Errors = append(testStatus.Errors, e)
+		testStatus.ReadErrors++
+	} else {
+		testStatus.ReadOps++
+	}
+}

--- a/cmd/gemini/schema.go
+++ b/cmd/gemini/schema.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/scylladb/gemini"
+	"go.uber.org/zap"
+)
+
+func createSchemaConfig(logger *zap.Logger) gemini.SchemaConfig {
+	defaultConfig := createDefaultSchemaConfig(logger)
+	switch strings.ToLower(datasetSize) {
+	case "small":
+		return gemini.SchemaConfig{
+			CompactionStrategy: defaultConfig.CompactionStrategy,
+			MaxPartitionKeys:   defaultConfig.MaxPartitionKeys,
+			MaxClusteringKeys:  defaultConfig.MaxClusteringKeys,
+			MaxColumns:         defaultConfig.MaxColumns,
+			MaxUDTParts:        2,
+			MaxTupleParts:      2,
+			MaxBlobLength:      20,
+			MaxStringLength:    20,
+			CQLFeature:         defaultConfig.CQLFeature,
+		}
+	default:
+		return defaultConfig
+	}
+}
+
+func createDefaultSchemaConfig(logger *zap.Logger) gemini.SchemaConfig {
+	const (
+		MaxBlobLength   = 1e4
+		MinBlobLength   = 0
+		MaxStringLength = 1000
+		MinStringLength = 0
+		MaxTupleParts   = 20
+		MaxUDTParts     = 20
+	)
+	return gemini.SchemaConfig{
+		CompactionStrategy: getCompactionStrategy(compactionStrategy, logger),
+		MaxPartitionKeys:   3,
+		MaxClusteringKeys:  maxClusteringKeys,
+		MaxColumns:         maxColumns,
+		MaxUDTParts:        MaxUDTParts,
+		MaxTupleParts:      MaxTupleParts,
+		MaxBlobLength:      MaxBlobLength,
+		MinBlobLength:      MinBlobLength,
+		MaxStringLength:    MaxStringLength,
+		MinStringLength:    MinStringLength,
+		CQLFeature:         getCQLFeature(cqlFeatures),
+	}
+}

--- a/cmd/gemini/spinner.go
+++ b/cmd/gemini/spinner.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"time"
+
+	"github.com/briandowns/spinner"
+)
+
+func createSpinner() *spinner.Spinner {
+	spinnerCharSet := []string{"|", "/", "-", "\\"}
+	sp := spinner.New(spinnerCharSet, 1*time.Second)
+	_ = sp.Color("black")
+	sp.Start()
+	return sp
+}

--- a/cmd/gemini/status.go
+++ b/cmd/gemini/status.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/briandowns/spinner"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+type Status struct {
+	WriteOps    int        `json:"write_ops"`
+	WriteErrors int        `json:"write_errors"`
+	ReadOps     int        `json:"read_ops"`
+	ReadErrors  int        `json:"read_errors"`
+	Errors      []JobError `json:"errors,omitempty"`
+}
+
+func (r *Status) Merge(sum *Status) Status {
+	sum.WriteOps += r.WriteOps
+	sum.WriteErrors += r.WriteErrors
+	sum.ReadOps += r.ReadOps
+	sum.ReadErrors += r.ReadErrors
+	sum.Errors = append(sum.Errors, r.Errors...)
+	return *sum
+}
+
+func (r *Status) PrintResult(w io.Writer) {
+	if err := r.PrintResultAsJSON(w); err != nil {
+		// In case there has been it has been a long run we want to display it anyway...
+		fmt.Printf("Unable to print result as json, using plain text to stdout, error=%s\n", err)
+		fmt.Printf("Gemini version: %s\n", version)
+		fmt.Printf("Results:\n")
+		fmt.Printf("\twrite ops:    %v\n", r.WriteOps)
+		fmt.Printf("\tread ops:     %v\n", r.ReadOps)
+		fmt.Printf("\twrite errors: %v\n", r.WriteErrors)
+		fmt.Printf("\tread errors:  %v\n", r.ReadErrors)
+		for i, err := range r.Errors {
+			fmt.Printf("Error %d: %s\n", i, err)
+		}
+	}
+}
+
+func (r *Status) PrintResultAsJSON(w io.Writer) error {
+	result := map[string]interface{}{
+		"result":         r,
+		"gemini_version": version,
+	}
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent(" ", " ")
+	if err := encoder.Encode(result); err != nil {
+		return errors.Wrap(err, "unable to create json from result")
+	}
+	return nil
+}
+
+func (r Status) String() string {
+	return fmt.Sprintf("write ops: %v | read ops: %v | write errors: %v | read errors: %v", r.WriteOps, r.ReadOps, r.WriteErrors, r.ReadErrors)
+}
+
+func sampleStatus(p *Pump, c chan Status, sp *spinner.Spinner, logger *zap.Logger) Status {
+	logger = logger.Named("sample_results")
+	var testRes Status
+	done := false
+	for res := range c {
+		testRes = res.Merge(&testRes)
+		if sp != nil {
+			sp.Suffix = fmt.Sprintf(" Running Gemini... %v", testRes)
+		}
+		if testRes.ReadErrors > 0 || testRes.WriteErrors > 0 {
+			if failFast {
+				if !done {
+					done = true
+					logger.Warn("Errors detected. Exiting.")
+					p.Stop()
+				}
+			}
+		}
+	}
+	return testRes
+}

--- a/generator_test.go
+++ b/generator_test.go
@@ -1,0 +1,44 @@
+package gemini
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGenerator(t *testing.T) {
+	cfg := &GeneratorsConfig{
+		Partitions: PartitionRangeConfig{
+			MaxStringLength: 10,
+			MinStringLength: 0,
+			MaxBlobLength:   10,
+			MinBlobLength:   0,
+		},
+		Size:             1,
+		PkBufferSize:     10000,
+		PkUsedBufferSize: 10000,
+		Table: &Table{
+			Name:          "tbl",
+			PartitionKeys: createPkColumns(1, "pk"),
+		},
+	}
+	generators := NewGenerator(cfg)
+	source := generators.Get(0)
+
+	time.Sleep(time.Second)
+
+	if size := len(source.newValues); size != 10000 {
+		t.Errorf("expected %d pks got %d", 10000, size)
+	}
+	if size := len(source.oldValues); size != 0 {
+		t.Errorf("expected %d spent pks got %d", 0, size)
+	}
+
+	generators.Stop()
+	cnt := 0
+	for range source.newValues {
+		cnt++
+	}
+	if cnt < 10000 {
+		t.Errorf("expected at least %d pks after stop got %d", 10000, cnt)
+	}
+}

--- a/routing_key.go
+++ b/routing_key.go
@@ -7,16 +7,6 @@ import (
 	"github.com/gocql/gocql"
 )
 
-const (
-	protoDirectionMask = 0x80
-	protoVersionMask   = 0x7F
-	protoVersion1      = 0x01
-	protoVersion2      = 0x02
-	protoVersion3      = 0x03
-	protoVersion4      = 0x04
-	protoVersion5      = 0x05
-)
-
 type RoutingKeyCreator struct {
 	routingKeyBuffer []byte
 }

--- a/types.go
+++ b/types.go
@@ -38,10 +38,19 @@ const (
 	TYPE_UUID      = SimpleType("uuid")
 	TYPE_VARCHAR   = SimpleType("varchar")
 	TYPE_VARINT    = SimpleType("varint")
+
+	protoDirectionMask = 0x80
+	protoVersionMask   = 0x7F
+	protoVersion1      = 0x01
+	protoVersion2      = 0x02
+	protoVersion3      = 0x03
+	protoVersion4      = 0x04
+	protoVersion5      = 0x05
 )
 
 // TODO: Add support for time when gocql bug is fixed.
 var (
+	partitionKeyTypes     = []SimpleType{TYPE_INT, TYPE_SMALLINT, TYPE_TINYINT, TYPE_VARINT}
 	pkTypes               = []SimpleType{TYPE_ASCII, TYPE_BIGINT, TYPE_BLOB, TYPE_DATE, TYPE_DECIMAL, TYPE_DOUBLE, TYPE_FLOAT, TYPE_INET, TYPE_INT, TYPE_SMALLINT, TYPE_TEXT /*TYPE_TIME,*/, TYPE_TIMESTAMP, TYPE_TIMEUUID, TYPE_TINYINT, TYPE_UUID, TYPE_VARCHAR, TYPE_VARINT}
 	types                 = append(append([]SimpleType{}, pkTypes...), TYPE_BOOLEAN, TYPE_DURATION)
 	compatibleColumnTypes = map[SimpleType][]SimpleType{
@@ -606,6 +615,10 @@ func genMapType(sc *SchemaConfig) MapType {
 		ValueType: genSimpleType(sc),
 		Frozen:    rand.Uint32()%2 == 0,
 	}
+}
+
+func genPartitionKeyColumnType() Type {
+	return partitionKeyTypes[rand.Intn(len(partitionKeyTypes))]
 }
 
 func genPrimaryKeyColumnType() Type {


### PR DESCRIPTION
A dedictated source concept is introduced and producing and consuming
partition keys are both coordinated through this object. The size of
the buffers governing how many partition keys are buffered can be
controlled through the CLI args `partition-key-buffer-size` and
`partition-key-buffer-reuse-size` respectively.

The `concurrency` concept is somewhat changed into meaning that
each `job` is running with this number of goroutines. So for
a `mixed` mode it means that `2*concurrency` number of goroutines
will be running at the same time. You may need to rescale your
command line arg `concurrency` accordingly.

Relates to: #158 