### PR TITLE
gemini: Fix indefinite hang if warmup is set to zero

### DIFF
--- a/cmd/gemini/root.go
+++ b/cmd/gemini/root.go
@@ -204,14 +204,14 @@ func run(cmd *cobra.Command, args []string) {
 }
 
 func launch(schema *gemini.Schema, schemaConfig gemini.SchemaConfig, store store.Store, pump *Pump, generators []*gemini.Generators, result chan Status, logger *zap.Logger) {
-	done := &sync.WaitGroup{}
-	done.Add(1)
 	if warmup > 0 {
+		done := &sync.WaitGroup{}
+		done.Add(1)
 		job(done, WarmupJob, concurrency, schema, schemaConfig, store, pump, generators, result, logger)
+		done.Wait()
+		logger.Info("Warmup done")
 	}
-	done.Wait()
-	logger.Info("Warmup done")
-	done = &sync.WaitGroup{}
+	done := &sync.WaitGroup{}
 	done.Add(1)
 	switch mode {
 	case writeMode:


### PR DESCRIPTION
If user passes "--warmup=0s", the launch() function skips the actual
job, but still waits on the waitgroup. This causes the tool to hang.

Fixes #169.