### PR TITLE
gemini: makes sure the result is updated on termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# Unreleased
+
+- Bugfix that makes sure that when a job terminates early, the result status is
+  properly sent to the collector.
+
 # 1.4.2 
 
 - Reused primary keys does no longer block the caller if none are available.

--- a/cmd/gemini/jobs.go
+++ b/cmd/gemini/jobs.go
@@ -34,6 +34,7 @@ func MutationJob(ctx context.Context, pump <-chan heartBeat, wg *sync.WaitGroup,
 			testStatus = Status{}
 		}
 		if failFast && (testStatus.ReadErrors > 0 || testStatus.WriteErrors > 0) {
+			c <- testStatus
 			break
 		}
 		i++
@@ -57,6 +58,7 @@ func ValidationJob(ctx context.Context, pump <-chan heartBeat, wg *sync.WaitGrou
 			testStatus = Status{}
 		}
 		if failFast && (testStatus.ReadErrors > 0 || testStatus.WriteErrors > 0) {
+			c <- testStatus
 			break
 		}
 		i++
@@ -76,6 +78,7 @@ func WarmupJob(ctx context.Context, pump <-chan heartBeat, wg *sync.WaitGroup, s
 		case _, ok := <-pump:
 			if !ok {
 				logger.Info("warmup job terminated")
+				c <- testStatus
 				return
 			}
 		}


### PR DESCRIPTION
When an error is encountered, the result status was not sent back to the collecting goroutine.

Fixes: #176 