### PR TITLE
schema: replication strategy is now supported

### DIFF
--- a/cmd/gemini/schema.go
+++ b/cmd/gemini/schema.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/scylladb/gemini"
+	"github.com/scylladb/gemini/replication"
 	"go.uber.org/zap"
 )
 
@@ -12,18 +13,19 @@ func createSchemaConfig(logger *zap.Logger) gemini.SchemaConfig {
 	switch strings.ToLower(datasetSize) {
 	case "small":
 		return gemini.SchemaConfig{
-			CompactionStrategy: defaultConfig.CompactionStrategy,
-			MaxPartitionKeys:   defaultConfig.MaxPartitionKeys,
-			MinPartitionKeys:   defaultConfig.MinPartitionKeys,
-			MaxClusteringKeys:  defaultConfig.MaxClusteringKeys,
-			MinClusteringKeys:  defaultConfig.MinClusteringKeys,
-			MaxColumns:         defaultConfig.MaxColumns,
-			MinColumns:         defaultConfig.MinColumns,
-			MaxUDTParts:        2,
-			MaxTupleParts:      2,
-			MaxBlobLength:      20,
-			MaxStringLength:    20,
-			CQLFeature:         defaultConfig.CQLFeature,
+			CompactionStrategy:  defaultConfig.CompactionStrategy,
+			ReplicationStrategy: defaultConfig.ReplicationStrategy,
+			MaxPartitionKeys:    defaultConfig.MaxPartitionKeys,
+			MinPartitionKeys:    defaultConfig.MinPartitionKeys,
+			MaxClusteringKeys:   defaultConfig.MaxClusteringKeys,
+			MinClusteringKeys:   defaultConfig.MinClusteringKeys,
+			MaxColumns:          defaultConfig.MaxColumns,
+			MinColumns:          defaultConfig.MinColumns,
+			MaxUDTParts:         2,
+			MaxTupleParts:       2,
+			MaxBlobLength:       20,
+			MaxStringLength:     20,
+			CQLFeature:          defaultConfig.CQLFeature,
 		}
 	default:
 		return defaultConfig
@@ -40,19 +42,20 @@ func createDefaultSchemaConfig(logger *zap.Logger) gemini.SchemaConfig {
 		MaxUDTParts     = 20
 	)
 	return gemini.SchemaConfig{
-		CompactionStrategy: getCompactionStrategy(compactionStrategy, logger),
-		MaxPartitionKeys:   maxPartitionKeys,
-		MinPartitionKeys:   minPartitionKeys,
-		MaxClusteringKeys:  maxClusteringKeys,
-		MinClusteringKeys:  minClusteringKeys,
-		MaxColumns:         maxColumns,
-		MinColumns:         minColumns,
-		MaxUDTParts:        MaxUDTParts,
-		MaxTupleParts:      MaxTupleParts,
-		MaxBlobLength:      MaxBlobLength,
-		MinBlobLength:      MinBlobLength,
-		MaxStringLength:    MaxStringLength,
-		MinStringLength:    MinStringLength,
-		CQLFeature:         getCQLFeature(cqlFeatures),
+		CompactionStrategy:  getCompactionStrategy(compactionStrategy, logger),
+		ReplicationStrategy: getReplicationStrategy(replicationStrategy, replication.NewSimpleStrategy(), logger),
+		MaxPartitionKeys:    maxPartitionKeys,
+		MinPartitionKeys:    minPartitionKeys,
+		MaxClusteringKeys:   maxClusteringKeys,
+		MinClusteringKeys:   minClusteringKeys,
+		MaxColumns:          maxColumns,
+		MinColumns:          minColumns,
+		MaxUDTParts:         MaxUDTParts,
+		MaxTupleParts:       MaxTupleParts,
+		MaxBlobLength:       MaxBlobLength,
+		MinBlobLength:       MinBlobLength,
+		MaxStringLength:     MaxStringLength,
+		MinStringLength:     MinStringLength,
+		CQLFeature:          getCQLFeature(cqlFeatures),
 	}
 }

--- a/replication/replication.go
+++ b/replication/replication.go
@@ -1,0 +1,27 @@
+package replication
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type Replication map[string]interface{}
+
+func (r *Replication) ToCQL() string {
+	b, _ := json.Marshal(r)
+	return strings.ReplaceAll(string(b), "\"", "'")
+}
+
+func NewSimpleStrategy() *Replication {
+	return &Replication{
+		"class":              "SimpleStrategy",
+		"replication_factor": 1,
+	}
+}
+
+func NewNetworkTopologyStrategy() *Replication {
+	return &Replication{
+		"class":       "NetworkTopologyStrategy",
+		"datacenter1": 1,
+	}
+}

--- a/replication/replication_test.go
+++ b/replication/replication_test.go
@@ -1,0 +1,29 @@
+package replication
+
+import (
+	"testing"
+)
+
+func TestToCQL(t *testing.T) {
+	tests := map[string]struct {
+		rs   *Replication
+		want string
+	}{
+		"simple": {
+			rs:   NewSimpleStrategy(),
+			want: "{'class':'SimpleStrategy','replication_factor':1}",
+		},
+		"network": {
+			rs:   NewNetworkTopologyStrategy(),
+			want: "{'class':'NetworkTopologyStrategy','datacenter1':1}",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := test.rs.ToCQL()
+			if got != test.want {
+				t.Fatalf("expected '%s', got '%s'", test.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two default CLI arguments "simple" and "network" gives the simplest
possible default values of the respective strategy, SimpleStrategy
and NetworkTopologyStrategy respectively.

Alternatively the entire CQL specification (JSON-ish) can be sent in and
gemini will then try to interpret it directly.

Fixes: #190 