### PR TITLE
gemini: added CQL tracing support

### DIFF
--- a/store/cqlstore.go
+++ b/store/cqlstore.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"io"
 	"time"
 
 	"github.com/gocql/gocql"
@@ -100,10 +101,13 @@ func (cs cqlStore) close() error {
 	return nil
 }
 
-func newSession(cluster *gocql.ClusterConfig) *gocql.Session {
+func newSession(cluster *gocql.ClusterConfig, out io.Writer) *gocql.Session {
 	session, err := cluster.CreateSession()
 	if err != nil {
 		panic(err)
+	}
+	if out != nil {
+		session.SetTrace(gocql.NewTraceWriter(session, out))
 	}
 	return session
 }


### PR DESCRIPTION
A new CLI argument "tracing" is added that toggles tracing on and
off with default set to off.

The tracer logs the contents of the `system_traces.sessions` and `system_traces.events`.

Fixes: #195 