### PR TITLE
Support generating multiple tables per keyspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# Unreleased
+
+- Add support for generating multiple tables in schema with the `--max-tables`
+  command line option.
+
 # [1.6.0] - 2019-09-06
 
 - Bumped driver version to v1.3.0-rc.1

--- a/cmd/gemini/root.go
+++ b/cmd/gemini/root.go
@@ -48,6 +48,7 @@ var (
 	compactionStrategy       string
 	replicationStrategy      string
 	consistency              string
+	maxTables                int
 	maxPartitionKeys         int
 	minPartitionKeys         int
 	maxClusteringKeys        int
@@ -438,6 +439,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&compactionStrategy, "compaction-strategy", "", "", "Specify the desired CS as either the coded short hand stcs|twcs|lcs to get the default for each type or provide the entire specification in the form {'class':'....'}")
 	rootCmd.Flags().StringVarP(&replicationStrategy, "replication-strategy", "", "simple", "Specify the desired replication strategy as either the coded short hand simple|network to get the default for each type or provide the entire specification in the form {'class':'....'}")
 	rootCmd.Flags().StringVarP(&consistency, "consistency", "", "QUORUM", "Specify the desired consistency as ANY|ONE|TWO|THREE|QUORUM|LOCAL_QUORUM|EACH_QUORUM|LOCAL_ONE")
+	rootCmd.Flags().IntVarP(&maxTables, "max-tables", "", 1, "Maximum number of generated tables")
 	rootCmd.Flags().IntVarP(&maxPartitionKeys, "max-partition-keys", "", 6, "Maximum number of generated partition keys")
 	rootCmd.Flags().IntVarP(&minPartitionKeys, "min-partition-keys", "", 2, "Minimum number of generated partition keys")
 	rootCmd.Flags().IntVarP(&maxClusteringKeys, "max-clustering-keys", "", 4, "Maximum number of generated clustering keys")

--- a/cmd/gemini/schema.go
+++ b/cmd/gemini/schema.go
@@ -15,6 +15,7 @@ func createSchemaConfig(logger *zap.Logger) gemini.SchemaConfig {
 		return gemini.SchemaConfig{
 			CompactionStrategy:  defaultConfig.CompactionStrategy,
 			ReplicationStrategy: defaultConfig.ReplicationStrategy,
+			MaxTables:           defaultConfig.MaxTables,
 			MaxPartitionKeys:    defaultConfig.MaxPartitionKeys,
 			MinPartitionKeys:    defaultConfig.MinPartitionKeys,
 			MaxClusteringKeys:   defaultConfig.MaxClusteringKeys,
@@ -45,6 +46,7 @@ func createDefaultSchemaConfig(logger *zap.Logger) gemini.SchemaConfig {
 	return gemini.SchemaConfig{
 		CompactionStrategy:  getCompactionStrategy(compactionStrategy, logger),
 		ReplicationStrategy: getReplicationStrategy(replicationStrategy, replication.NewSimpleStrategy(), logger),
+		MaxTables:           maxTables,
 		MaxPartitionKeys:    maxPartitionKeys,
 		MinPartitionKeys:    minPartitionKeys,
 		MaxClusteringKeys:   maxClusteringKeys,

--- a/docs/cli-arguments.md
+++ b/docs/cli-arguments.md
@@ -42,3 +42,5 @@ performed. Default is 30 seconds.
 
 10. ___--outfile___: Path to a file where Gemini should store it's result. If not provided then
 standard out is used.
+
+11. ___--max-tables___: Maximum number of tables in the generated schema.

--- a/schema.go
+++ b/schema.go
@@ -28,6 +28,7 @@ type Value []interface{}
 type SchemaConfig struct {
 	CompactionStrategy  *CompactionStrategy
 	ReplicationStrategy *replication.Replication
+	MaxTables           int
 	MaxPartitionKeys    int
 	MinPartitionKeys    int
 	MaxClusteringKeys   int
@@ -61,6 +62,10 @@ func (sc *SchemaConfig) Valid() error {
 		return SchemaConfigInvalidCols
 	}
 	return nil
+}
+
+func (sc *SchemaConfig) GetMaxTables() int {
+	return sc.MaxTables
 }
 
 func (sc *SchemaConfig) GetMaxPartitionKeys() int {
@@ -371,8 +376,11 @@ func GenSchema(sc SchemaConfig) *Schema {
 		Replication: sc.ReplicationStrategy,
 	}
 	builder.Keyspace(keyspace)
-	table := createTable(sc, "table1")
-	builder.Table(&table)
+	numTables := 1 + rand.Intn(sc.GetMaxTables())
+	for i := 0; i < numTables; i++ {
+		table := createTable(sc, fmt.Sprintf("table%d", i + 1))
+		builder.Table(&table)
+	}
 	return builder.Build()
 }
 


### PR DESCRIPTION
This pull request adds a new `--max-tables N` command line option, which specifies the maximum number of tables generated per keyspace. The default value is set to `1` for backwards compatibility, but we might want to revisit that later.

Fixes #202.