### PR TITLE
gemini: min-columns correctly set in CLI

### DIFF
--- a/cmd/gemini/root.go
+++ b/cmd/gemini/root.go
@@ -464,7 +464,7 @@ func init() {
 	rootCmd.Flags().IntVarP(&maxClusteringKeys, "max-clustering-keys", "", 4, "Maximum number of generated clustering keys")
 	rootCmd.Flags().IntVarP(&minClusteringKeys, "min-clustering-keys", "", 2, "Minimum number of generated clustering keys")
 	rootCmd.Flags().IntVarP(&maxColumns, "max-columns", "", 16, "Maximum number of generated columns")
-	rootCmd.Flags().IntVarP(&maxColumns, "min-columns", "", 8, "Minimum number of generated columns")
+	rootCmd.Flags().IntVarP(&minColumns, "min-columns", "", 8, "Minimum number of generated columns")
 	rootCmd.Flags().StringVarP(&datasetSize, "dataset-size", "", "large", "Specify the type of dataset size to use, small|large")
 	rootCmd.Flags().StringVarP(&cqlFeatures, "cql-features", "", "basic", "Specify the type of cql features to use, basic|normal|all")
 	rootCmd.Flags().StringVarP(&level, "level", "", "info", "Specify the logging level, debug|info|warn|error|dpanic|panic|fatal")


### PR DESCRIPTION
It used to set the incorrect property maxColumns instead of
minColumns.

Fixes: #224 