### PR TITLE
gemini: Avoid DDL operations for a table with MV

### DIFF
--- a/cmd/gemini/jobs.go
+++ b/cmd/gemini/jobs.go
@@ -140,6 +140,10 @@ func ddl(ctx context.Context, schema *gemini.Schema, sc *gemini.SchemaConfig, ta
 		return
 	}
 	table.Lock()
+	if len(table.MaterializedViews) > 0 {
+		// Scylla does not allow changing the DDL of a table with materialized views.
+		return
+	}
 	defer table.Unlock()
 	ddlStmts, postStmtHook, err := schema.GenDDLStmt(table, r, p, sc)
 	if err != nil {


### PR DESCRIPTION
Scylla does not allow dropping a column that is part of a materialized
view. Let's avoid doing DDL operations altogether for such cases to be
safe.

Fixes #230