### PR TITLE
gemini: attempts to shutdown more precisely

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,26 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Build
+    env:
+    runs-on: ubuntu-latest
+    steps:
+      - steps:
+          - uses: actions/checkout@v2
+          - name: Setup Go
+            uses: actions/setup-go@v2
+            with:
+              go-version: latest
+
+          - name: Unit Tests
+              run: go test -v -race ./...
+
+          - name: Build
+              run: go build .

--- a/cmd/gemini/generators.go
+++ b/cmd/gemini/generators.go
@@ -15,11 +15,13 @@
 package main
 
 import (
+	"context"
+
 	"github.com/scylladb/gemini"
 	"go.uber.org/zap"
 )
 
-func createGenerators(schema *gemini.Schema, schemaConfig gemini.SchemaConfig, distributionFunc gemini.DistributionFunc, actors, distributionSize uint64, logger *zap.Logger) []*gemini.Generator {
+func createGenerators(ctx context.Context, schema *gemini.Schema, schemaConfig gemini.SchemaConfig, distributionFunc gemini.DistributionFunc, actors, distributionSize uint64, logger *zap.Logger) []*gemini.Generator {
 	partitionRangeConfig := gemini.PartitionRangeConfig{
 		MaxBlobLength:   schemaConfig.MaxBlobLength,
 		MinBlobLength:   schemaConfig.MinBlobLength,
@@ -36,7 +38,7 @@ func createGenerators(schema *gemini.Schema, schemaConfig gemini.SchemaConfig, d
 			Seed:                       seed,
 			PkUsedBufferSize:           pkBufferReuseSize,
 		}
-		g := gemini.NewGenerator(table, gCfg, logger.Named("generator"))
+		g := gemini.NewGenerator(ctx, table, gCfg, logger.Named("generator"))
 		gs = append(gs, g)
 	}
 	return gs

--- a/cmd/gemini/pump.go
+++ b/cmd/gemini/pump.go
@@ -15,20 +15,18 @@
 package main
 
 import (
+	"context"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
-	"github.com/briandowns/spinner"
-	"github.com/scylladb/gemini"
 	"go.uber.org/zap"
-	"gopkg.in/tomb.v2"
 )
 
 type Pump struct {
+	ctx      context.Context
 	ch       chan heartBeat
-	t        *tomb.Tomb
 	graceful chan os.Signal
 	logger   *zap.Logger
 }
@@ -43,57 +41,35 @@ func (hb heartBeat) await() {
 	}
 }
 
-func (p *Pump) Start(d time.Duration, postFunc func()) {
-	p.t.Go(func() error {
-		defer p.cleanup(postFunc)
-		timer := time.NewTimer(d)
-		for {
-			select {
-			case <-p.t.Dying():
-				p.logger.Info("Test run stopped. Exiting.")
-				return nil
-			case <-p.graceful:
-				p.logger.Info("Test run aborted. Exiting.")
-				p.t.Kill(nil)
-				return nil
-			case <-timer.C:
-				p.logger.Info("Test run completed. Exiting.")
-				p.t.Kill(nil)
-				return nil
-			case p.ch <- newHeartBeat():
-			}
+func (p *Pump) Start(ctx context.Context, done context.CancelFunc) error {
+	defer p.cleanup()
+	for {
+		select {
+		case <-ctx.Done():
+			p.logger.Info("Test run stopped. Exiting.")
+			return ctx.Err()
+		case <-p.graceful:
+			p.logger.Info("Test run aborted. Exiting.")
+			done()
+			return ctx.Err()
+		case p.ch <- newHeartBeat():
 		}
-	})
-}
-
-func (p *Pump) cleanup(postFunc func()) {
-	close(p.ch)
-	for range p.ch {
 	}
-	p.logger.Debug("pump channel drained")
-	postFunc()
 }
 
-func createPump(t *tomb.Tomb, sz int, logger *zap.Logger) *Pump {
+func (p *Pump) cleanup() {
+	close(p.ch)
+	p.logger.Debug("pump channel closed")
+}
+
+func createPump(sz int, logger *zap.Logger) *Pump {
 	logger = logger.Named("pump")
 	var graceful = make(chan os.Signal, 1)
 	signal.Notify(graceful, syscall.SIGTERM, syscall.SIGINT)
 	pump := &Pump{
 		ch:       make(chan heartBeat, sz),
-		t:        t,
 		graceful: graceful,
 		logger:   logger,
 	}
 	return pump
-}
-
-func createPumpCallback(generators []*gemini.Generator, result chan Status, sp *spinner.Spinner) func() {
-	return func() {
-		if sp != nil {
-			sp.Stop()
-		}
-		for _, g := range generators {
-			g.Stop()
-		}
-	}
 }

--- a/cmd/gemini/spinner.go
+++ b/cmd/gemini/spinner.go
@@ -15,15 +15,37 @@
 package main
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/briandowns/spinner"
 )
 
-func createSpinner() *spinner.Spinner {
+type spinningFeedback struct {
+	s *spinner.Spinner
+}
+
+func (sf *spinningFeedback) Set(format string, args ...interface{}) {
+	if sf.s != nil {
+		sf.s.Suffix = fmt.Sprintf(format, args...)
+	}
+}
+
+func (sf *spinningFeedback) Stop() {
+	if sf.s != nil {
+		sf.s.Stop()
+	}
+}
+
+func createSpinner(active bool) *spinningFeedback {
+	if !active {
+		return &spinningFeedback{}
+	}
 	spinnerCharSet := []string{"|", "/", "-", "\\"}
 	sp := spinner.New(spinnerCharSet, 1*time.Second)
 	_ = sp.Color("black")
 	sp.Start()
-	return sp
+	return &spinningFeedback{
+		s: sp,
+	}
 }

--- a/generator_test.go
+++ b/generator_test.go
@@ -15,6 +15,7 @@
 package gemini
 
 import (
+	"context"
 	"sync/atomic"
 	"testing"
 
@@ -41,7 +42,7 @@ func TestGenerator(t *testing.T) {
 		},
 	}
 	logger, _ := zap.NewDevelopment()
-	generators := NewGenerator(table, cfg, logger)
+	generators := NewGenerator(context.Background(), table, cfg, logger)
 	for i := uint64(0); i < cfg.PartitionsCount; i++ {
 		atomic.StoreUint64(&current, i)
 		v, _ := generators.Get()

--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,15 @@ module github.com/scylladb/gemini
 go 1.12
 
 require (
-	github.com/briandowns/spinner v0.0.0-20190311160019-998b3556fb3f
-	github.com/fatih/color v1.7.0 // indirect
-	github.com/gocql/gocql v0.0.0-20190423091413-b99afaf3b163
+	github.com/briandowns/spinner v1.11.1
+	github.com/gocql/gocql v0.0.0-20200103014340-68f928edb90a
 	github.com/google/go-cmp v0.2.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/mattn/go-colorable v0.1.1 // indirect
-	github.com/mattn/go-isatty v0.0.6 // indirect
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3
 	github.com/scylladb/go-set v1.0.2
-	github.com/scylladb/gocqlx v1.3.1
+	github.com/scylladb/gocqlx v1.3.3
 	github.com/segmentio/ksuid v1.0.2
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
@@ -23,10 +20,13 @@ require (
 	go.uber.org/zap v1.10.0
 	golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522
 	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3
+	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	golang.org/x/sys v0.0.0-20190412213103-97732733099d // indirect
 	gonum.org/v1/gonum v0.0.0-20190724133715-a8659125a966
 	gopkg.in/inf.v0 v0.9.1
-	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
 )
 
-replace github.com/gocql/gocql => github.com/scylladb/gocql v1.3.1
+replace (
+	github.com/gocql/gocql => github.com/scylladb/gocql v1.3.1
+	golang.org/x/sync => golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
+)

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 h1:mXoPYz/Ul5HYE
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
-github.com/briandowns/spinner v0.0.0-20190311160019-998b3556fb3f h1:MABudtpeYW3sx6sh8sy8k8nPRIQTTvGUOvmUbdvlIGM=
-github.com/briandowns/spinner v0.0.0-20190311160019-998b3556fb3f/go.mod h1:hw/JEQBIE+c/BLI4aKM8UU8v+ZqrD3h7HC27kKt8JQU=
+github.com/briandowns/spinner v1.11.1 h1:OixPqDEcX3juo5AjQZAnFPbeUA0jvkp2qzB5gOZJ/L0=
+github.com/briandowns/spinner v1.11.1/go.mod h1:QOuQk7x+EaDASo80FEXwlwiA+j/PPIcX3FScO+3/ZPQ=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -49,11 +49,10 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/mattn/go-colorable v0.1.1 h1:G1f5SKeVxmagw/IyvzvtZE4Gybcc4Tr1tf7I8z0XgOg=
-github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
-github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
-github.com/mattn/go-isatty v0.0.6 h1:SrwhHcpV4nWrMGdNcC2kXpMfcBVYGDuTArqyhocJgvA=
-github.com/mattn/go-isatty v0.0.6/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
@@ -83,8 +82,8 @@ github.com/scylladb/go-set v1.0.2 h1:SkvlMCKhP0wyyct6j+0IHJkBkSZL+TDzZ4E7f7BCcRE
 github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/scylladb/gocql v1.3.1 h1:LkK3OXns6QaMTJrMlWTCGroSnrt/7u1UfBcDzEeU6u0=
 github.com/scylladb/gocql v1.3.1/go.mod h1:DL0ekTmBSTdlNF25Orwt/JMzqIq3EJ4MVa/J/uK64OY=
-github.com/scylladb/gocqlx v1.3.1 h1:NTiKaSW1RzDxHQIyPE/KubOJCKRG5xXMUG8FKVKR/j0=
-github.com/scylladb/gocqlx v1.3.1/go.mod h1:1CisD8Z+VB7ByxGyc3B9OXusRNgWWtCMkO+hNCpgZAc=
+github.com/scylladb/gocqlx v1.3.3 h1:p4R6sDDPvkmIMBlomKw+WyGmQc7o9LM3JlFDtcT+PoM=
+github.com/scylladb/gocqlx v1.3.3/go.mod h1:g+GaoDa4O9T/THP3z1TdA589P7ZyxVm+/Zj897g6DUc=
 github.com/segmentio/ksuid v1.0.2 h1:9yBfKyw4ECGTdALaF09Snw3sLJmYIX6AbPJrAy6MrDc=
 github.com/segmentio/ksuid v1.0.2/go.mod h1:BXuJDr2byAiHuQaQtSKoXh1J0YmUDurywOXgB2w+OSU=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -118,8 +117,8 @@ golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a h1:WXEvlFVvvGxCJLG6REjsT03iWnKLEWinaScsxF2Vm2o=
+golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -144,7 +143,5 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637 h1:yiW+nvdHb9LVqSHQBXfZCieqV4fzYhNBql77zY0ykqs=
-gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637/go.mod h1:BHsqpu/nsuzkT5BpiH1EMZPLyqSMM8JbIavyFACoFNk=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=

--- a/partition.go
+++ b/partition.go
@@ -15,15 +15,16 @@
 package gemini
 
 import (
+	"context"
+
 	"github.com/scylladb/gemini/inflight"
-	"gopkg.in/tomb.v2"
 )
 
 type Partition struct {
+	ctx       context.Context
 	values    chan ValueWithToken
 	oldValues chan ValueWithToken
 	inFlight  inflight.InFlight
-	t         *tomb.Tomb
 }
 
 // get returns a new value and ensures that it's corresponding token
@@ -43,7 +44,7 @@ var emptyValueWithToken = ValueWithToken{}
 // the old queue is empty.
 func (s *Partition) getOld() (ValueWithToken, bool) {
 	select {
-	case <-s.t.Dying():
+	case <-s.ctx.Done():
 		return emptyValueWithToken, false
 	case v, ok := <-s.oldValues:
 		return v, ok

--- a/schema.go
+++ b/schema.go
@@ -320,7 +320,6 @@ func (t *Table) alterColumn(keyspace string) ([]*Stmt, func(), error) {
 			},
 			QueryType: AlterColumnStatementType,
 		})
-		fmt.Println(stmt)
 		return stmts, func() {
 			t.Columns[idx] = newColumn
 		}, nil

--- a/store/cqlstore.go
+++ b/store/cqlstore.go
@@ -50,7 +50,11 @@ func (cs *cqlStore) mutate(ctx context.Context, builder qb.Builder, ts time.Time
 		if err == nil {
 			break
 		}
-		time.Sleep(cs.maxRetriesMutateSleep)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(cs.maxRetriesMutateSleep):
+		}
 	}
 	if err != nil {
 		if w := cs.logger.Check(zap.InfoLevel, "failed to apply mutation"); w != nil {


### PR DESCRIPTION
Using 'golang.org/x/sync/errgroup' instead of Tomb. Simplifying
the nested goroutines and returns errors more frequently.

Fixes: #226 