### PR TITLE
store: don't enable tracing if not requested

### DIFF
--- a/store/cqlstore.go
+++ b/store/cqlstore.go
@@ -16,7 +16,7 @@ package store
 
 import (
 	"context"
-	"io"
+	"os"
 	"time"
 
 	"github.com/gocql/gocql"
@@ -119,7 +119,7 @@ func (cs cqlStore) close() error {
 	return nil
 }
 
-func newSession(cluster *gocql.ClusterConfig, out io.Writer) *gocql.Session {
+func newSession(cluster *gocql.ClusterConfig, out *os.File) *gocql.Session {
 	session, err := cluster.CreateSession()
 	if err != nil {
 		panic(err)

--- a/store/store.go
+++ b/store/store.go
@@ -17,8 +17,8 @@ package store
 import (
 	"context"
 	"fmt"
-	"io"
 	"math/big"
+	"os"
 	"sort"
 	"time"
 
@@ -64,7 +64,7 @@ type Config struct {
 	MaxRetriesMutateSleep time.Duration
 }
 
-func New(schema *gemini.Schema, testCluster *gocql.ClusterConfig, oracleCluster *gocql.ClusterConfig, cfg Config, traceOut io.Writer, logger *zap.Logger) Store {
+func New(schema *gemini.Schema, testCluster *gocql.ClusterConfig, oracleCluster *gocql.ClusterConfig, cfg Config, traceOut *os.File, logger *zap.Logger) Store {
 	ops := promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "gemini_cql_requests",
 		Help: "How many CQL requests processed, partitioned by system and CQL query type aka 'method' (batch, delete, insert, update).",


### PR DESCRIPTION
The `newSession` function compared `out` (the tracing output
destination) with `nil` to decide if tracing should be enabled on the
created session.

Although the underlying value of `out` was `nil *os.File`, it was passed
in as `io.Writer`. However, `nil *os.File` is a non-`nil` `io.Writer`,
so the `out != nil` check always passed.

Fixes #247.