### PR TITLE
Remove some recursive table read locks

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -749,10 +749,7 @@ func (s *Schema) genInsertJsonStmt(t *Table, g *Generator, r *rand.Rand, p Parti
 	}, nil
 }
 
-func (s *Schema) GenDeleteRows(t *Table, g *Generator, r *rand.Rand, p PartitionRangeConfig) (*Stmt, error) {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
+func (s *Schema) genDeleteRows(t *Table, g *Generator, r *rand.Rand, p PartitionRangeConfig) (*Stmt, error) {
 	var (
 		typs []Type
 	)
@@ -804,7 +801,7 @@ func (s *Schema) GenMutateStmt(t *Table, g *Generator, r *rand.Rand, p Partition
 	}
 	switch n := rand.Intn(1000); n {
 	case 10, 100:
-		return s.GenDeleteRows(t, g, r, p)
+		return s.genDeleteRows(t, g, r, p)
 	default:
 		switch n := rand.Intn(2); n {
 		case 0:

--- a/schema.go
+++ b/schema.go
@@ -690,10 +690,7 @@ func (s *Schema) insertStmt(t *Table, g *Generator, r *rand.Rand, p PartitionRan
 	}, nil
 }
 
-func (s *Schema) GenInsertJsonStmt(t *Table, g *Generator, r *rand.Rand, p PartitionRangeConfig) (*Stmt, error) {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
+func (s *Schema) genInsertJsonStmt(t *Table, g *Generator, r *rand.Rand, p PartitionRangeConfig) (*Stmt, error) {
 	if isCounterTable(t) {
 		return nil, nil
 	}
@@ -814,7 +811,7 @@ func (s *Schema) GenMutateStmt(t *Table, g *Generator, r *rand.Rand, p Partition
 			if t.KnownIssues[KnownIssuesJsonWithTuples] {
 				return s.genInsertStmt(t, g, r, p)
 			}
-			return s.GenInsertJsonStmt(t, g, r, p)
+			return s.genInsertJsonStmt(t, g, r, p)
 		default:
 			return s.genInsertStmt(t, g, r, p)
 		}

--- a/schema.go
+++ b/schema.go
@@ -596,10 +596,7 @@ func (s *Schema) GetCreateSchema() []string {
 	return stmts
 }
 
-func (s *Schema) GenInsertStmt(t *Table, g *Generator, r *rand.Rand, p PartitionRangeConfig) (*Stmt, error) {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
+func (s *Schema) genInsertStmt(t *Table, g *Generator, r *rand.Rand, p PartitionRangeConfig) (*Stmt, error) {
 	if isCounterTable(t) {
 		return s.updateStmt(t, g, r, p)
 	}
@@ -806,7 +803,7 @@ func (s *Schema) GenMutateStmt(t *Table, g *Generator, r *rand.Rand, p Partition
 	defer t.mu.RUnlock()
 
 	if !deletes {
-		return s.GenInsertStmt(t, g, r, p)
+		return s.genInsertStmt(t, g, r, p)
 	}
 	switch n := rand.Intn(1000); n {
 	case 10, 100:
@@ -815,11 +812,11 @@ func (s *Schema) GenMutateStmt(t *Table, g *Generator, r *rand.Rand, p Partition
 		switch n := rand.Intn(2); n {
 		case 0:
 			if t.KnownIssues[KnownIssuesJsonWithTuples] {
-				return s.GenInsertStmt(t, g, r, p)
+				return s.genInsertStmt(t, g, r, p)
 			}
 			return s.GenInsertJsonStmt(t, g, r, p)
 		default:
-			return s.GenInsertStmt(t, g, r, p)
+			return s.genInsertStmt(t, g, r, p)
 		}
 	}
 }


### PR DESCRIPTION
This pull requests removes recursive "t.mu" table read locks -- which
can deadlock -- from the functions the `GenMutateStmt()` function calls.

Refs #246