### PR TITLE
Fix mutex unlocking in ddl() function

### DIFF
--- a/cmd/gemini/jobs.go
+++ b/cmd/gemini/jobs.go
@@ -165,11 +165,11 @@ func ddl(ctx context.Context, schema *gemini.Schema, sc *gemini.SchemaConfig, ta
 		return nil
 	}
 	table.Lock()
+	defer table.Unlock()
 	if len(table.MaterializedViews) > 0 {
 		// Scylla does not allow changing the DDL of a table with materialized views.
 		return nil
 	}
-	defer table.Unlock()
 	ddlStmts, postStmtHook, err := schema.GenDDLStmt(table, r, p, sc)
 	if err != nil {
 		logger.Error("Failed! Mutation statement generation failed", zap.Error(err))


### PR DESCRIPTION
As explained by Henrik Johansson:

"If it has a materialized view the lock will be kept in perpetuity since
the code returns without unlocking the lock."

Fix it up.