### PR TITLE
Create indexes only if they dont already exist

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -564,7 +564,7 @@ func (s *Schema) GetCreateSchema() []string {
 		createTable := t.GetCreateTable(s.Keyspace)
 		stmts = append(stmts, createTable)
 		for _, idef := range t.Indexes {
-			stmts = append(stmts, fmt.Sprintf("CREATE INDEX %s ON %s.%s (%s)", idef.Name, s.Keyspace.Name, t.Name, idef.Column))
+			stmts = append(stmts, fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON %s.%s (%s)", idef.Name, s.Keyspace.Name, t.Name, idef.Column))
 		}
 		for _, mv := range t.MaterializedViews {
 			var (


### PR DESCRIPTION
gemini fails if an index already exists (--drop-schema=false)

```
Error: unable to create schema: unable to apply mutations to the test store: [cluster = test, query = 'CREATE INDEX col0_idx ON ks1.table1 (col0)']: Index col0_idx already exists
unable to create schema: unable to apply mutations to the test store: [cluster = test, query = 'CREATE INDEX col0_idx ON ks1.table1 (col0)']: Index col0_idx already exists

```