### PR TITLE
Print sample status to stdout if error detected

### DIFF
--- a/cmd/gemini/status.go
+++ b/cmd/gemini/status.go
@@ -97,6 +97,7 @@ func sampleStatus(ctx context.Context, c chan Status, sp *spinningFeedback, logg
 			testRes.Merge(res)
 			sp.Set(" Running Gemini... %v", testRes)
 			if testRes.ReadErrors > 0 || testRes.WriteErrors > 0 {
+				fmt.Printf("Errors detected: %#v", testRes.Errors)
 				if failFast {
 					failfastDone.Do(func() {
 						logger.Warn("Errors detected. Exiting.")


### PR DESCRIPTION
Due to issue https://github.com/scylladb/gemini/issues/236
gemini result file could be not created.

Let print the Sample result to stdout if error detected.
This allow to investigate issue while the #236 is not fixed