### PR TITLE
Fix query create mv

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -582,9 +582,9 @@ func (s *Schema) GetCreateSchema() []string {
 			}
 			var createMaterializedView string
 			if len(mv.PartitionKeys) == 1 {
-				createMaterializedView = "CREATE MATERIALIZED VIEW %s.%s AS SELECT * FROM %s.%s WHERE %s PRIMARY KEY (%s"
+				createMaterializedView = "CREATE MATERIALIZED VIEW IF NOT EXISTS %s.%s AS SELECT * FROM %s.%s WHERE %s PRIMARY KEY (%s"
 			} else {
-				createMaterializedView = "CREATE MATERIALIZED VIEW %s.%s AS SELECT * FROM %s.%s WHERE %s PRIMARY KEY ((%s)"
+				createMaterializedView = "CREATE MATERIALIZED VIEW IF NOT EXISTS %s.%s AS SELECT * FROM %s.%s WHERE %s PRIMARY KEY ((%s)"
 			}
 			createMaterializedView = createMaterializedView + ",%s)"
 			stmts = append(stmts, fmt.Sprintf(createMaterializedView,


### PR DESCRIPTION
Gemini could failed with error:
Error: unable to create schema: unable to apply mutations to the test store:
[cluster = test, query = 'CREATE MATERIALIZED VIEW ks1.table1_mv_0 AS SELECT * FROM ks1.table1
 WHERE col10 IS NOT NULL AND pk0 IS NOT NULL AND pk1 IS NOT NULL AND pk2 IS NOT NULL AND pk3 IS NOT NULL AND
ck0 IS NOT NULL AND ck1 IS NOT NULL AND ck2 IS NOT NULL PRIMARY KEY ((col10,pk0,pk1,pk2,pk3),ck0,ck1,ck2)']:
 Cannot add already existing table "table1_mv_0" to keyspace "ks1"

Add to query "IF NOT EXISTS" "CREATE MATERIALIZED VIEW IF NOT EXISTS %s.%s AS SELECT * FROM %s.%s WHERE %s PRIMARY KEY"