### PR TITLE
fix error handling in load function

### DIFF
--- a/store/cqlstore.go
+++ b/store/cqlstore.go
@@ -106,10 +106,10 @@ func (cs *cqlStore) load(ctx context.Context, builder qb.Builder, values []inter
 	iter := cs.session.Query(query, values...).WithContext(ctx).Iter()
 	cs.ops.WithLabelValues(cs.system, opType(builder)).Inc()
 	defer func() {
-		if e := iter.Close(); err != nil {
+		if e := iter.Close(); e != nil {
 			if e == context.DeadlineExceeded {
 				if w := cs.logger.Check(zap.DebugLevel, "deadline exceeded for load query"); w != nil {
-					w.Write(zap.String("system", cs.system), zap.String("query", query), zap.Error(err))
+					w.Write(zap.String("system", cs.system), zap.String("query", query), zap.Error(e))
 				}
 			}
 			if !ignore(e) {


### PR DESCRIPTION
Condition statement in load function was wrong - 'err` variable was
never assigned. This caused to ignore cql errors and leading to wrong
validation error message.

This commit fixes variable assignment, so validation error message in
test results is more appropriate.

fixes: https://github.com/scylladb/scylla-cluster-tests/issues/4694