### PR TITLE
fix(inflight): reduce memory footprint by using struct{} instead of bool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,3 +43,6 @@ check: check-golangci
 # fix make all static code analysis tools to fix the issues
 .PHONY: fix
 fix: fix-golangci
+
+.PHONY: test
+test: go test -v -race ./...


### PR DESCRIPTION
Reduce memory foot print for `inflight` registry by using `struct{}` instead of `bool`
Also add test for shrinking