### PR TITLE
fix(schema): delivery values and partition range config as pointers

### DIFF
--- a/cmd/gemini/jobs.go
+++ b/cmd/gemini/jobs.go
@@ -39,7 +39,7 @@ func MutationJob(
 	table *gemini.Table,
 	s store.Store,
 	r *rand.Rand,
-	p gemini.PartitionRangeConfig,
+	p *gemini.PartitionRangeConfig,
 	g *gemini.Generator,
 	c chan Status,
 	_ string,
@@ -96,7 +96,7 @@ func ValidationJob(
 	table *gemini.Table,
 	s store.Store,
 	r *rand.Rand,
-	p gemini.PartitionRangeConfig,
+	p *gemini.PartitionRangeConfig,
 	g *gemini.Generator,
 	c chan Status,
 	_ string,
@@ -158,7 +158,7 @@ func WarmupJob(
 	table *gemini.Table,
 	s store.Store,
 	r *rand.Rand,
-	p gemini.PartitionRangeConfig,
+	p *gemini.PartitionRangeConfig,
 	g *gemini.Generator,
 	c chan Status,
 	_ string,
@@ -226,7 +226,7 @@ func job(
 		for i := 0; i < int(actors); i++ {
 			r := rand.New(rand.NewSource(seed))
 			g.Go(func() error {
-				return f(gCtx, pump.ch, schema, schemaConfig, table, s, r, partitionRangeConfig, gen, result, mode, warmup, logger)
+				return f(gCtx, pump.ch, schema, schemaConfig, table, s, r, &partitionRangeConfig, gen, result, mode, warmup, logger)
 			})
 		}
 	}
@@ -240,7 +240,7 @@ func ddl(
 	table *gemini.Table,
 	s store.Store,
 	r *rand.Rand,
-	p gemini.PartitionRangeConfig,
+	p *gemini.PartitionRangeConfig,
 	testStatus *Status,
 	logger *zap.Logger,
 ) error {
@@ -299,7 +299,7 @@ func mutation(
 	table *gemini.Table,
 	s store.Store,
 	r *rand.Rand,
-	p gemini.PartitionRangeConfig,
+	p *gemini.PartitionRangeConfig,
 	g *gemini.Generator,
 	testStatus *Status,
 	deletes bool,

--- a/cmd/gemini/root.go
+++ b/cmd/gemini/root.go
@@ -128,7 +128,7 @@ type testJob func(
 	*gemini.Table,
 	store.Store,
 	*rand.Rand,
-	gemini.PartitionRangeConfig,
+	*gemini.PartitionRangeConfig,
 	*gemini.Generator,
 	chan Status,
 	string,

--- a/columns.go
+++ b/columns.go
@@ -74,7 +74,7 @@ func (c Columns) Names() []string {
 	return names
 }
 
-func (c Columns) ToJSONMap(values map[string]interface{}, r *rand.Rand, p PartitionRangeConfig) map[string]interface{} {
+func (c Columns) ToJSONMap(values map[string]interface{}, r *rand.Rand, p *PartitionRangeConfig) map[string]interface{} {
 	for _, k := range c {
 		switch t := k.Type.(type) {
 		case SimpleType:

--- a/datautils.go
+++ b/datautils.go
@@ -73,6 +73,6 @@ func randIpV4Address(rnd *rand.Rand, v, pos int) string {
 	return strings.Join(blocks, ".")
 }
 
-func appendValue(columnType Type, r *rand.Rand, p PartitionRangeConfig, values []interface{}) []interface{} {
+func appendValue(columnType Type, r *rand.Rand, p *PartitionRangeConfig, values []interface{}) []interface{} {
 	return append(values, columnType.GenValue(r, p)...)
 }

--- a/generator.go
+++ b/generator.go
@@ -156,7 +156,7 @@ func (g *Generator) start() {
 func (g *Generator) createPartitionKeyValues(r *rand.Rand) []interface{} {
 	var values []interface{}
 	for _, pk := range g.table.PartitionKeys {
-		values = append(values, pk.Type.GenValue(r, g.partitionsConfig)...)
+		values = append(values, pk.Type.GenValue(r, &g.partitionsConfig)...)
 	}
 	return values
 }

--- a/types.go
+++ b/types.go
@@ -257,7 +257,7 @@ func (st SimpleType) Indexable() bool {
 	return st != TYPE_DURATION
 }
 
-func (st SimpleType) GenValue(r *rand.Rand, p PartitionRangeConfig) []interface{} {
+func (st SimpleType) GenValue(r *rand.Rand, p *PartitionRangeConfig) []interface{} {
 	var val interface{}
 	switch st {
 	case TYPE_ASCII, TYPE_TEXT, TYPE_VARCHAR:
@@ -356,7 +356,7 @@ func (t *TupleType) Indexable() bool {
 	return true
 }
 
-func (t *TupleType) GenValue(r *rand.Rand, p PartitionRangeConfig) []interface{} {
+func (t *TupleType) GenValue(r *rand.Rand, p *PartitionRangeConfig) []interface{} {
 	out := make([]interface{}, 0, len(t.Types))
 	for _, tp := range t.Types {
 		out = append(out, tp.GenValue(r, p)...)
@@ -415,7 +415,7 @@ func (t *UDTType) Indexable() bool {
 	return true
 }
 
-func (t *UDTType) GenValue(r *rand.Rand, p PartitionRangeConfig) []interface{} {
+func (t *UDTType) GenValue(r *rand.Rand, p *PartitionRangeConfig) []interface{} {
 	vals := make(map[string]interface{})
 	for name, typ := range t.Types {
 		vals[name] = typ.GenValue(r, p)[0]
@@ -475,7 +475,7 @@ func (ct *BagType) CQLPretty(query string, value []interface{}) (string, int) {
 	panic(fmt.Sprintf("set cql pretty, unknown type %v", ct))
 }
 
-func (ct *BagType) GenValue(r *rand.Rand, p PartitionRangeConfig) []interface{} {
+func (ct *BagType) GenValue(r *rand.Rand, p *PartitionRangeConfig) []interface{} {
 	count := r.Intn(9) + 1
 	out := make([]interface{}, count)
 	for i := 0; i < count; i++ {
@@ -525,7 +525,7 @@ func (mt *MapType) CQLPretty(query string, value []interface{}) (string, int) {
 	panic(fmt.Sprintf("map cql pretty, unknown type %v", mt))
 }
 
-func (mt *MapType) GenValue(r *rand.Rand, p PartitionRangeConfig) []interface{} {
+func (mt *MapType) GenValue(r *rand.Rand, p *PartitionRangeConfig) []interface{} {
 	count := r.Intn(9) + 1
 	vals := make(map[interface{}]interface{})
 	for i := 0; i < count; i++ {
@@ -565,7 +565,7 @@ func (ct *CounterType) CQLPretty(query string, value []interface{}) (string, int
 	return strings.Replace(query, "?", fmt.Sprintf("%d", value[0]), 1), 1
 }
 
-func (ct *CounterType) GenValue(r *rand.Rand, p PartitionRangeConfig) []interface{} {
+func (ct *CounterType) GenValue(r *rand.Rand, p *PartitionRangeConfig) []interface{} {
 	return []interface{}{atomic.AddInt64(&ct.Value, 1)}
 }
 


### PR DESCRIPTION
Part of #298, addressed following issues:
1. `PartitionRangeConfig` is passed all way down as struct, which makes golang to allocate memory for it on multiple times for every iteration
2.  `ValueWithToken` is passed all way down as struct, which makes golang to allocate memory for it on multiple times for every iteration