### PR TITLE
fix(inflight): reduce shrinking limit

### DIFF
--- a/inflight/inflight.go
+++ b/inflight/inflight.go
@@ -21,7 +21,7 @@ import (
 // We track inflights in the map, maps in golang are not shrinking
 // Therefore we track how many inflights were deleted and when it reaches the limit
 // we forcefully recreate the map to shrink it
-const shrinkInflightsLimit = 1000000
+const shrinkInflightsLimit = 1000
 
 type InFlight interface {
 	AddIfNotPresent(uint64) bool


### PR DESCRIPTION
Part of https://github.com/scylladb/gemini/issues/298

Inflights are initialized per partition, so limit of `1000000` makes no sense