### PR TITLE
fix(generator): reduce memory allocations

### DIFF
--- a/generator_test.go
+++ b/generator_test.go
@@ -44,8 +44,8 @@ func TestGenerator(t *testing.T) {
 	generators := NewGenerator(context.Background(), table, cfg, logger)
 	for i := uint64(0); i < cfg.PartitionsCount; i++ {
 		atomic.StoreUint64(&current, i)
-		v, _ := generators.Get()
-		n, _ := generators.Get()
+		v := generators.Get()
+		n := generators.Get()
 		if v.Token%generators.partitionCount != n.Token%generators.partitionCount {
 			t.Errorf("expected %v, got %v", v, n)
 		}


### PR DESCRIPTION
Part of https://github.com/scylladb/gemini/issues/298

1. Convert generator methods to use pointer receiver
2. Optimize PK values turnover
3. Convert channels to pointers