### PR TITLE
lt function have wrong compare for big.Int

### DIFF
--- a/store/helpers.go
+++ b/store/helpers.go
@@ -73,7 +73,7 @@ func lt(mi, mj map[string]interface{}) bool {
 		return mis.UnixNano() < mjs.UnixNano()
 	case *big.Int:
 		mjs, _ := mj["pk0"].(*big.Int)
-		return mis.Cmp(mjs) > 0
+		return mis.Cmp(mjs) < 0
 	default:
 		msg := fmt.Sprintf("unhandled type %T\n", mis)
 		time.Sleep(time.Second)


### PR DESCRIPTION
For example in this function compare for int8:
```
	case int8:
		mjs, _ := mj["pk0"].(int8)
		return mis < mjs
```
Code:
```
	x := big.NewInt(1)
	y := big.NewInt(10)
	fmt.Println(x.Cmp(y) < 0)
//Output:true
```

