### PR TITLE
fix(root.createClusters): Use request-timeout parameter for Oracle

### DIFF
--- a/cmd/gemini/root.go
+++ b/cmd/gemini/root.go
@@ -371,7 +371,8 @@ func createClusters(
 		return testCluster, nil
 	}
 	oracleCluster := gocql.NewCluster(oracleClusterHost...)
-	oracleCluster.Timeout = 120 * time.Second
+	testCluster.Timeout = requestTimeout
+	testCluster.ConnectTimeout = connectTimeout
 	oracleCluster.RetryPolicy = retryPolicy
 	oracleCluster.Consistency = consistency
 	oracleCluster.PoolConfig.HostSelectionPolicy = oracleHostSelectionPolicy


### PR DESCRIPTION
Oracle cluster use fixed request timeout 120s, while test cluster user configurable request timeout provided by --request-timeout parameter. This cause request time for queries to oracle cluster for MV, SI.

Set same parameter for Oracle cluster