### PR TITLE
feat(generators): impelemt statement cache

### DIFF
--- a/pkg/builders/builders.go
+++ b/pkg/builders/builders.go
@@ -15,6 +15,7 @@
 package builders
 
 import (
+	"github.com/scylladb/gemini/pkg/querycache"
 	"github.com/scylladb/gemini/pkg/testschema"
 	"github.com/scylladb/gemini/pkg/typedef"
 )
@@ -49,7 +50,11 @@ func (s *schemaBuilder) Table(table *testschema.Table) SchemaBuilder {
 }
 
 func (s *schemaBuilder) Build() *testschema.Schema {
-	return &testschema.Schema{Keyspace: s.keyspace, Tables: s.tables}
+	out := &testschema.Schema{Keyspace: s.keyspace, Tables: s.tables}
+	for id := range s.tables {
+		s.tables[id].Init(out, querycache.New(out))
+	}
+	return out
 }
 
 func NewSchemaBuilder() SchemaBuilder {

--- a/pkg/coltypes/bag.go
+++ b/pkg/coltypes/bag.go
@@ -86,6 +86,10 @@ func (ct *BagType) GenValue(r *rand.Rand, p *typedef.PartitionRangeConfig) []int
 	return []interface{}{out}
 }
 
+func (ct *BagType) LenValue() int {
+	return 1
+}
+
 func (ct *BagType) Indexable() bool {
 	return false
 }

--- a/pkg/coltypes/simple_type.go
+++ b/pkg/coltypes/simple_type.go
@@ -63,6 +63,10 @@ func (st SimpleType) CQLHolder() string {
 	return "?"
 }
 
+func (st SimpleType) LenValue() int {
+	return 1
+}
+
 func (st SimpleType) CQLPretty(query string, value []interface{}) (string, int) {
 	if len(value) == 0 {
 		return query, 0

--- a/pkg/coltypes/tuple.go
+++ b/pkg/coltypes/tuple.go
@@ -83,3 +83,11 @@ func (t *TupleType) GenValue(r *rand.Rand, p *typedef.PartitionRangeConfig) []in
 	}
 	return out
 }
+
+func (t *TupleType) LenValue() int {
+	out := 0
+	for _, tp := range t.Types {
+		out += tp.LenValue()
+	}
+	return out
+}

--- a/pkg/coltypes/types.go
+++ b/pkg/coltypes/types.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/exp/rand"
 
 	"github.com/scylladb/gemini/pkg/typedef"
+	"github.com/scylladb/gemini/pkg/utils"
 )
 
 const (
@@ -144,6 +145,10 @@ func (mt *MapType) GenValue(r *rand.Rand, p *typedef.PartitionRangeConfig) []int
 	return []interface{}{vals}
 }
 
+func (mt *MapType) LenValue() int {
+	return 1
+}
+
 func (mt *MapType) CQLDef() string {
 	if mt.Frozen {
 		return "frozen<map<" + mt.KeyType.CQLDef() + "," + mt.ValueType.CQLDef() + ">>"
@@ -176,7 +181,14 @@ func (ct *CounterType) CQLPretty(query string, value []interface{}) (string, int
 }
 
 func (ct *CounterType) GenValue(r *rand.Rand, p *typedef.PartitionRangeConfig) []interface{} {
+	if utils.UnderTest {
+		return []interface{}{r.Int63()}
+	}
 	return []interface{}{atomic.AddInt64(&ct.Value, 1)}
+}
+
+func (ct *CounterType) LenValue() int {
+	return 1
 }
 
 func (ct *CounterType) CQLDef() string {

--- a/pkg/coltypes/udt.go
+++ b/pkg/coltypes/udt.go
@@ -82,3 +82,7 @@ func (t *UDTType) GenValue(r *rand.Rand, p *typedef.PartitionRangeConfig) []inte
 	}
 	return []interface{}{vals}
 }
+
+func (t *UDTType) LenValue() int {
+	return 1
+}

--- a/pkg/generators/schema_mutation_stmt_test.go
+++ b/pkg/generators/schema_mutation_stmt_test.go
@@ -16,6 +16,8 @@ package generators
 
 import (
 	"testing"
+
+	"github.com/scylladb/gemini/pkg/utils"
 )
 
 var (
@@ -51,6 +53,8 @@ var (
 )
 
 func TestGenInsertStmt(t *testing.T) {
+	utils.SetUnderTest()
+	t.Parallel()
 	expected := initExpected(t, "insert.json", genInsertStmtCases, *updateExpected)
 	if *updateExpected {
 		defer expected.updateExpected(t)
@@ -59,7 +63,7 @@ func TestGenInsertStmt(t *testing.T) {
 		caseName := genInsertStmtCases[idx]
 		t.Run(caseName,
 			func(subT *testing.T) {
-				schema, prc, gen, rnd, useLWT, _ := getAllForTestStmt(subT, genInsertStmtCases[idx])
+				schema, prc, gen, rnd, useLWT, _ := getAllForTestStmt(subT, caseName)
 				stmt, err := genInsertStmt(schema, schema.Tables[0], gen.Get(), rnd, prc, useLWT)
 				validateStmt(subT, stmt, err)
 				expected.CompareOrStore(subT, caseName, stmt)
@@ -68,6 +72,8 @@ func TestGenInsertStmt(t *testing.T) {
 }
 
 func TestGenUpdateStmt(t *testing.T) {
+	utils.SetUnderTest()
+	t.Parallel()
 	expected := initExpected(t, "update.json", genUpdateStmtCases, *updateExpected)
 	if *updateExpected {
 		defer expected.updateExpected(t)
@@ -76,7 +82,7 @@ func TestGenUpdateStmt(t *testing.T) {
 		caseName := genUpdateStmtCases[idx]
 		t.Run(caseName,
 			func(subT *testing.T) {
-				schema, prc, gen, rnd, _, _ := getAllForTestStmt(subT, genUpdateStmtCases[idx])
+				schema, prc, gen, rnd, _, _ := getAllForTestStmt(subT, caseName)
 				stmt, err := genUpdateStmt(schema, schema.Tables[0], gen.Get(), rnd, prc)
 				validateStmt(subT, stmt, err)
 				expected.CompareOrStore(subT, caseName, stmt)
@@ -85,6 +91,8 @@ func TestGenUpdateStmt(t *testing.T) {
 }
 
 func TestGenDeleteRows(t *testing.T) {
+	utils.SetUnderTest()
+	t.Parallel()
 	expected := initExpected(t, "delete.json", genDeleteStmtCases, *updateExpected)
 	if *updateExpected {
 		defer expected.updateExpected(t)
@@ -93,7 +101,7 @@ func TestGenDeleteRows(t *testing.T) {
 		caseName := genDeleteStmtCases[idx]
 		t.Run(caseName,
 			func(subT *testing.T) {
-				schema, prc, gen, rnd, _, _ := getAllForTestStmt(subT, genDeleteStmtCases[idx])
+				schema, prc, gen, rnd, _, _ := getAllForTestStmt(subT, caseName)
 				stmt, err := genDeleteRows(schema, schema.Tables[0], gen.Get(), rnd, prc)
 				validateStmt(subT, stmt, err)
 				expected.CompareOrStore(subT, caseName, stmt)
@@ -102,6 +110,7 @@ func TestGenDeleteRows(t *testing.T) {
 }
 
 func BenchmarkGenInsertStmt(t *testing.B) {
+	utils.SetUnderTest()
 	for idx := range genInsertStmtCases {
 		caseName := genInsertStmtCases[idx]
 		t.Run(caseName,
@@ -116,6 +125,7 @@ func BenchmarkGenInsertStmt(t *testing.B) {
 }
 
 func BenchmarkGenUpdateStmt(t *testing.B) {
+	utils.SetUnderTest()
 	for idx := range genUpdateStmtCases {
 		caseName := genUpdateStmtCases[idx]
 		t.Run(caseName,
@@ -130,6 +140,7 @@ func BenchmarkGenUpdateStmt(t *testing.B) {
 }
 
 func BenchmarkGenDeleteRows(t *testing.B) {
+	utils.SetUnderTest()
 	for idx := range genDeleteStmtCases {
 		caseName := genDeleteStmtCases[idx]
 		t.Run(caseName,

--- a/pkg/generators/suite_utils_test.go
+++ b/pkg/generators/suite_utils_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"golang.org/x/exp/rand"
 
 	"github.com/scylladb/gemini/pkg/builders"
@@ -30,10 +31,6 @@ import (
 	"github.com/scylladb/gemini/pkg/routingkey"
 	"github.com/scylladb/gemini/pkg/tableopts"
 	"github.com/scylladb/gemini/pkg/testschema"
-	"github.com/scylladb/gemini/pkg/utils"
-
-	"github.com/pkg/errors"
-
 	"github.com/scylladb/gemini/pkg/typedef"
 )
 
@@ -139,16 +136,16 @@ func getErrorMsgIfDifferent(t *testing.T, expected, received, errMsg string) {
 		// Inject nice row that highlights differences if length is not changed
 		errMsgList = []string{
 			errMsg,
-			fmt.Sprintf("Expected⇶⇶⇶%s", expected),
+			fmt.Sprintf("Expected   %s", expected),
 			"           " + diffHighlightString(expected, received),
-			fmt.Sprintf("Received⇶⇶⇶%s", received),
+			fmt.Sprintf("Received   %s", received),
 			"-------------------------------------------",
 		}
 	case false:
 		errMsgList = []string{
 			errMsg,
-			fmt.Sprintf("Expected⇶⇶⇶%s", expected),
-			fmt.Sprintf("Received⇶⇶⇶%s", received),
+			fmt.Sprintf("Expected   %s", expected),
+			fmt.Sprintf("Received   %s", received),
 			"-------------------------------------------",
 		}
 	}
@@ -254,7 +251,6 @@ type testInterface interface {
 }
 
 func getAllForTestStmt(t testInterface, caseName string) (*testschema.Schema, *typedef.PartitionRangeConfig, *MockGenerator, *rand.Rand, bool, bool) {
-	utils.SetTestUUIDFromTime()
 	rnd := rand.New(nonRandSource(1))
 	table, useLWT, useMV := getTableAndOptionsFromName(t, caseName)
 

--- a/pkg/generators/test_expected_data/insert.json
+++ b/pkg/generators/test_expected_data/insert.json
@@ -60,7 +60,7 @@
       "TokenValues": "[1]",
       "Query": "INSERT INTO ks1.pk1_ck1_col1cr_lwt (pk0,ck0,col0) VALUES (?,?,?) IF NOT EXISTS",
       "Names": "[pk0 ck0 col0]",
-      "Values": "[1 1969-12-31 5]",
+      "Values": "[1 1969-12-31 1]",
       "Types": " bigint date counter",
       "QueryType": "5"
     }
@@ -71,7 +71,7 @@
       "TokenValues": "[1 1.110223e-16 1.1.1.1]",
       "Query": "INSERT INTO ks1.pk3_ck3_col3cr (pk0,pk1,pk2,ck0,ck1,ck2,col0,col1,col2) VALUES (?,?,?,?,?,?,?,?,?)",
       "Names": "[pk0 pk1 pk2 ck0 ck1 ck2 col0 col1 col2]",
-      "Values": "[1 1.110223e-16 1.1.1.1 01 1969-12-31 0.001 2 3 4]",
+      "Values": "[1 1.110223e-16 1.1.1.1 01 1969-12-31 0.001 1 1 1]",
       "Types": " bigint float inet ascii date decimal counter counter counter",
       "QueryType": "5"
     }

--- a/pkg/generators/test_expected_data/update.json
+++ b/pkg/generators/test_expected_data/update.json
@@ -49,7 +49,7 @@
       "TokenValues": "[1 1.110223e-16 1.1.1.1]",
       "Query": "UPDATE ks1.pk3_ck3_col5 SET col0=?,col1=?,col2=?,col3=?,col4=? WHERE pk0=? AND pk1=? AND pk2=? AND ck0=? AND ck1=? AND ck2=?",
       "Names": "[col0 col1 col2 col3 col4 pk0 pk1 pk2 ck0 ck1 ck2]",
-      "Values": "[00 1969-12-31 3030 1 1.110223e-16 1 1.110223e-16 1.1.1.1 01 1969-12-31 0.001]",
+      "Values": "[01 1969-12-31 3030 1 1.110223e-16 1 1.110223e-16 1.1.1.1 00 1969-12-31 0.001]",
       "Types": " ascii date blob bigint float bigint float inet ascii date decimal",
       "QueryType": "6"
     }

--- a/pkg/querycache/querycache.go
+++ b/pkg/querycache/querycache.go
@@ -1,0 +1,191 @@
+// Copyright 2019 ScyllaDB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package querycache
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/scylladb/gocqlx/v2/qb"
+
+	"github.com/scylladb/gemini/pkg/coltypes"
+	"github.com/scylladb/gemini/pkg/testschema"
+	"github.com/scylladb/gemini/pkg/typedef"
+)
+
+type QueryCache [typedef.CacheArrayLen]*typedef.StmtCache
+
+func (c QueryCache) Reset() {
+	for id := range c {
+		c[id] = nil
+	}
+}
+
+type Cache struct {
+	schema *testschema.Schema
+	table  *testschema.Table
+	cache  QueryCache
+	mu     sync.RWMutex
+}
+
+func New(s *testschema.Schema) *Cache {
+	return &Cache{
+		schema: s,
+	}
+}
+
+func (c *Cache) BindToTable(t *testschema.Table) {
+	c.table = t
+}
+
+func (c *Cache) Reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cache.Reset()
+}
+
+func (c *Cache) getQuery(qct typedef.StatementCacheType) *typedef.StmtCache {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	rec := c.cache[qct]
+	return rec
+}
+
+func (c *Cache) GetQuery(qct typedef.StatementCacheType) *typedef.StmtCache {
+	rec := c.getQuery(qct)
+	if rec != nil {
+		return rec
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	rec = CacheBuilders[qct](c.schema, c.table)
+	c.cache[qct] = rec
+	return rec
+}
+
+type CacheBuilderFn func(s *testschema.Schema, t *testschema.Table) *typedef.StmtCache
+
+type CacheBuilderFnMap map[typedef.StatementCacheType]CacheBuilderFn
+
+func (m CacheBuilderFnMap) ToList() [typedef.CacheArrayLen]CacheBuilderFn {
+	out := [typedef.CacheArrayLen]CacheBuilderFn{}
+	for idx, builderFn := range m {
+		out[idx] = builderFn
+	}
+	for idx := range out {
+		if out[idx] == nil {
+			panic(fmt.Sprintf("no builder for %s", typedef.StatementCacheType(idx).ToString()))
+		}
+	}
+	return out
+}
+
+var CacheBuilders = CacheBuilderFnMap{
+	typedef.CacheInsert:            genInsertStmtCache,
+	typedef.CacheInsertIfNotExists: genInsertIfNotExistsStmtCache,
+	typedef.CacheDelete:            genDeleteStmtCache,
+	typedef.CacheUpdate:            genUpdateStmtCache,
+}.ToList()
+
+func genInsertStmtCache(
+	s *testschema.Schema,
+	t *testschema.Table,
+) *typedef.StmtCache {
+	allTypes := make([]typedef.Type, 0, t.PartitionKeys.Len()+t.ClusteringKeys.Len()+t.Columns.Len())
+	builder := qb.Insert(s.Keyspace.Name + "." + t.Name)
+	for _, pk := range t.PartitionKeys {
+		builder = builder.Columns(pk.Name)
+		allTypes = append(allTypes, pk.Type)
+	}
+	for _, ck := range t.ClusteringKeys {
+		builder = builder.Columns(ck.Name)
+		allTypes = append(allTypes, ck.Type)
+	}
+	for _, col := range t.Columns {
+		switch colType := col.Type.(type) {
+		case *coltypes.TupleType:
+			builder = builder.TupleColumn(col.Name, len(colType.Types))
+		default:
+			builder = builder.Columns(col.Name)
+		}
+		allTypes = append(allTypes, col.Type)
+	}
+	return &typedef.StmtCache{
+		Query:     builder,
+		Types:     allTypes,
+		QueryType: typedef.InsertStatement,
+	}
+}
+
+func genInsertIfNotExistsStmtCache(
+	s *testschema.Schema,
+	t *testschema.Table,
+) *typedef.StmtCache {
+	out := genInsertStmtCache(s, t)
+	out.Query = out.Query.(*qb.InsertBuilder).Unique()
+	return out
+}
+
+func genUpdateStmtCache(s *testschema.Schema, t *testschema.Table) *typedef.StmtCache {
+	var allTypes []typedef.Type
+	builder := qb.Update(s.Keyspace.Name + "." + t.Name)
+
+	for _, cdef := range t.Columns {
+		switch t := cdef.Type.(type) {
+		case *coltypes.TupleType:
+			builder = builder.SetTuple(cdef.Name, len(t.Types))
+		case *coltypes.CounterType:
+			builder = builder.SetLit(cdef.Name, cdef.Name+"+1")
+			continue
+		default:
+			builder = builder.Set(cdef.Name)
+		}
+		allTypes = append(allTypes, cdef.Type)
+	}
+
+	for _, pk := range t.PartitionKeys {
+		builder = builder.Where(qb.Eq(pk.Name))
+		allTypes = append(allTypes, pk.Type)
+	}
+	for _, ck := range t.ClusteringKeys {
+		builder = builder.Where(qb.Eq(ck.Name))
+		allTypes = append(allTypes, ck.Type)
+	}
+	return &typedef.StmtCache{
+		Query:     builder,
+		Types:     allTypes,
+		QueryType: typedef.Updatetatement,
+	}
+}
+
+func genDeleteStmtCache(s *testschema.Schema, t *testschema.Table) *typedef.StmtCache {
+	var allTypes []typedef.Type
+	builder := qb.Delete(s.Keyspace.Name + "." + t.Name)
+	for _, pk := range t.PartitionKeys {
+		builder = builder.Where(qb.Eq(pk.Name))
+		allTypes = append(allTypes, pk.Type)
+	}
+
+	if len(t.ClusteringKeys) > 0 {
+		ck := t.ClusteringKeys[0]
+		builder = builder.Where(qb.GtOrEq(ck.Name)).Where(qb.LtOrEq(ck.Name))
+		allTypes = append(allTypes, ck.Type, ck.Type)
+	}
+	return &typedef.StmtCache{
+		Query:     builder,
+		Types:     allTypes,
+		QueryType: typedef.DeleteStatementType,
+	}
+}

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestSerialization(t *testing.T) {
+	t.Parallel()
 	//nolint:lll
 	expected := []byte(`{"errors":[{"timestamp":"2020-02-01T00:00:00Z","message":"Some Message 0","query":"Some Query 0"},{"timestamp":"2020-02-02T00:00:00Z","message":"Some Message 1","query":"Some Query 1"},{"timestamp":"2020-02-03T00:00:00Z","message":"Some Message 2","query":"Some Query 2"},{"timestamp":"2020-02-04T00:00:00Z","message":"Some Message 3","query":"Some Query 3"},{"timestamp":"2020-02-05T00:00:00Z","message":"Some Message 4","query":"Some Query 4"},{"timestamp":"2020-03-01T00:00:00Z","message":"Some Message 0","query":"Some Query 0"},{"timestamp":"2020-03-02T00:00:00Z","message":"Some Message 1","query":"Some Query 1"},{"timestamp":"2020-03-03T00:00:00Z","message":"Some Message 2","query":"Some Query 2"},{"timestamp":"2020-03-04T00:00:00Z","message":"Some Message 3","query":"Some Query 3"},{"timestamp":"2020-03-05T00:00:00Z","message":"Some Message 4","query":"Some Query 4"}],"write_ops":10,"write_errors":5,"read_ops":5,"read_errors":5}`)
 	st := status.NewGlobalStatus(10)

--- a/pkg/testschema/columns.go
+++ b/pkg/testschema/columns.go
@@ -72,6 +72,10 @@ func (cd *ColumnDef) UnmarshalJSON(data []byte) error {
 
 type Columns []*ColumnDef
 
+func (c Columns) Len() int {
+	return len(c)
+}
+
 func (c Columns) Names() []string {
 	names := make([]string, 0, len(c))
 	for _, col := range c {
@@ -123,6 +127,26 @@ func (c Columns) ValidColumnsForPrimaryKey() Columns {
 
 func (c Columns) Random() *ColumnDef {
 	return c[rand.Intn(len(c))]
+}
+
+func (c Columns) LenValues() int {
+	out := 0
+	for _, col := range c {
+		out += col.Type.LenValue()
+	}
+	return out
+}
+
+func (c Columns) NonCounters() Columns {
+	out := make(Columns, 0, len(c))
+	for _, col := range c {
+		switch col.Type.(type) {
+		case *coltypes.CounterType:
+			continue
+		}
+		out = append(out, col)
+	}
+	return out
 }
 
 func (c Columns) CreateMaterializedViews(tableName string, partitionKeys, clusteringKeys Columns) []MaterializedView {

--- a/pkg/typedef/typedef_test.go
+++ b/pkg/typedef/typedef_test.go
@@ -15,27 +15,27 @@
 package typedef
 
 import (
-	"github.com/gocql/gocql"
-	"golang.org/x/exp/rand"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
-type Type interface {
-	Name() string
-	CQLDef() string
-	CQLHolder() string
-	CQLPretty(string, []interface{}) (string, int)
-	GenValue(*rand.Rand, *PartitionRangeConfig) []interface{}
-	LenValue() int
-	Indexable() bool
-	CQLType() gocql.TypeInfo
-}
-
-type Types []Type
-
-func (l Types) LenValue() int {
-	out := 0
-	for _, t := range l {
-		out += t.LenValue()
+func TestValues(t *testing.T) {
+	tmp := make(Values, 0, 10)
+	expected := Values{1, 2, 3, 4, 5, 6, 7}
+	expected2 := Values{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	expected3 := Values{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	tmp = append(tmp, 1, 2, 3, 4, 5)
+	tmp = tmp.CopyFrom(Values{6, 7})
+	if !cmp.Equal(tmp, expected) {
+		t.Error("%i != %i", tmp, expected)
 	}
-	return out
+	tmp = tmp.CopyFrom(Values{8, 9})
+	if !cmp.Equal(tmp, expected2) {
+		t.Error("%i != %i", tmp, expected)
+	}
+	tmp = append(tmp, 10)
+	if !cmp.Equal(tmp, expected3) {
+		t.Error("%i != %i", tmp, expected)
+	}
 }

--- a/pkg/utils/undertest.go
+++ b/pkg/utils/undertest.go
@@ -12,30 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package typedef
+package utils
 
-import (
-	"github.com/gocql/gocql"
-	"golang.org/x/exp/rand"
-)
+var UnderTest = false
 
-type Type interface {
-	Name() string
-	CQLDef() string
-	CQLHolder() string
-	CQLPretty(string, []interface{}) (string, int)
-	GenValue(*rand.Rand, *PartitionRangeConfig) []interface{}
-	LenValue() int
-	Indexable() bool
-	CQLType() gocql.TypeInfo
-}
-
-type Types []Type
-
-func (l Types) LenValue() int {
-	out := 0
-	for _, t := range l {
-		out += t.LenValue()
-	}
-	return out
+func SetUnderTest() {
+	UnderTest = true
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -84,16 +84,9 @@ func RandString(rnd *rand.Rand, ln int) string {
 	return string(out[:ln])
 }
 
-var testUUIDFromTime bool
-
 func UUIDFromTime(rnd *rand.Rand) string {
-	if testUUIDFromTime {
+	if UnderTest {
 		return gocql.TimeUUIDWith(rnd.Int63(), 0, []byte("127.0.0.1")).String()
 	}
 	return gocql.UUIDFromTime(RandTime(rnd)).String()
-}
-
-func SetTestUUIDFromTime() {
-	// Makes TYPE_ASCII, TYPE_TEXT, TYPE_VARCHAR, TYPE_BLOB predictable
-	testUUIDFromTime = true
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -43,6 +43,5 @@ func TestRandString(t *testing.T) {
 		if len(out) != ln {
 			t.Fatalf("%d != %d", ln, len(out))
 		}
-		println(out)
 	}
 }


### PR DESCRIPTION
Every time we generate an operation we recreate statemet. 
Since some of the statement content could be cached we need to do that in sake of speeding things up.