### PR TITLE
fix(IndexDef): it should refer directly to index table column

### DIFF
--- a/pkg/generators/column.go
+++ b/pkg/generators/column.go
@@ -18,12 +18,12 @@ import (
 	"github.com/scylladb/gemini/pkg/typedef"
 )
 
-func CreateIndexesForColumn(c typedef.Columns, tableName string, maxIndexes int) []typedef.IndexDef {
+func CreateIndexesForColumn(table *typedef.Table, maxIndexes int) []typedef.IndexDef {
 	createdCount := 0
 	indexes := make([]typedef.IndexDef, 0, maxIndexes)
-	for i, col := range c {
+	for i, col := range table.Columns {
 		if col.Type.Indexable() && typedef.TypesForIndex.Contains(col.Type) {
-			indexes = append(indexes, typedef.IndexDef{Name: GenIndexName(tableName+"_col", i), Column: col.Name, ColumnIdx: i})
+			indexes = append(indexes, typedef.IndexDef{Name: GenIndexName(table.Name+"_col", i), Column: table.Columns[i]})
 			createdCount++
 		}
 		if createdCount == maxIndexes {

--- a/pkg/jobs/gen_check_stmt.go
+++ b/pkg/jobs/gen_check_stmt.go
@@ -521,9 +521,9 @@ func genSingleIndexQuery(
 	builder := qb.Select(s.Keyspace.Name + "." + t.Name)
 	builder.AllowFiltering()
 	for i := 0; i < idxCount; i++ {
-		builder = builder.Where(qb.Eq(t.Indexes[i].Column))
-		values = append(values, t.Columns[t.Indexes[i].ColumnIdx].Type.GenValue(r, p)...)
-		typs = append(typs, t.Columns[t.Indexes[i].ColumnIdx].Type)
+		builder = builder.Where(qb.Eq(t.Indexes[i].Column.Name))
+		values = append(values, t.Indexes[i].Column.Type.GenValue(r, p)...)
+		typs = append(typs, t.Indexes[i].Column.Type)
 	}
 
 	return &typedef.Stmt{

--- a/pkg/jobs/gen_utils_test.go
+++ b/pkg/jobs/gen_utils_test.go
@@ -478,15 +478,13 @@ func createIdxFromColumns(t testInterface, table *typedef.Table, all bool) (inde
 		for i := range table.Columns {
 			var index typedef.IndexDef
 			index.Name = table.Columns[i].Name + "_idx"
-			index.Column = table.Columns[i].Name
-			index.ColumnIdx = i
+			index.Column = table.Columns[i]
 			indexes = append(indexes, index)
 		}
 	default:
 		var index typedef.IndexDef
 		index.Name = table.Columns[0].Name + "_idx"
-		index.Column = table.Columns[0].Name
-		index.ColumnIdx = 0
+		index.Column = table.Columns[0]
 		indexes = append(indexes, index)
 
 	}

--- a/pkg/typedef/columns_test.go
+++ b/pkg/typedef/columns_test.go
@@ -79,11 +79,11 @@ func TestMarshalUnmarshal(t *testing.T) {
 				Indexes: []typedef.IndexDef{
 					{
 						Name:   generators.GenIndexName("col", 0),
-						Column: columns[0].Name,
+						Column: columns[0],
 					},
 					{
 						Name:   generators.GenIndexName("col", 1),
-						Column: columns[1].Name,
+						Column: columns[1],
 					},
 				},
 				MaterializedViews: []typedef.MaterializedView{

--- a/pkg/typedef/typedef.go
+++ b/pkg/typedef/typedef.go
@@ -34,9 +34,8 @@ type (
 	}
 
 	IndexDef struct {
-		Name      string `json:"name"`
-		Column    string `json:"column"`
-		ColumnIdx int    `json:"column_idx"`
+		Column *ColumnDef
+		Name   string `json:"name"`
 	}
 
 	PartitionRangeConfig struct {


### PR DESCRIPTION
'IndexDef' refers to table column by arrays id :
```
	IndexDef struct {
	...
		ColumnIdx int    `json:"column_idx"`
	}
```
And it is used like this:
```
	for i := 0; i < idxCount; i++ {
		builder = builder.Where(qb.Eq(t.Indexes[i].Column))
		values = append(values, t.Columns[t.Indexes[i].ColumnIdx].Type.GenValue(r, p)...)
		typs = append(typs, t.Columns[t.Indexes[i].ColumnIdx].Type)
	}
```
For example: If column with id=0 will be deleted and  'IndexDef' use column with id>0, as result - incorrect queries with 'IndexDef'.