### PR TITLE
fix(GenDDLStmt) column drops should be with conditions

### DIFF
--- a/pkg/jobs/gen_ddl_stmt.go
+++ b/pkg/jobs/gen_ddl_stmt.go
@@ -28,15 +28,16 @@ import (
 
 func GenDDLStmt(s *typedef.Schema, t *typedef.Table, r *rand.Rand, _ *typedef.PartitionRangeConfig, sc *typedef.SchemaConfig) (*typedef.Stmts, error) {
 	maxVariant := 1
-	if len(t.Columns) > 0 {
+	validCols := t.ValidColumnsForDelete()
+	if len(t.Columns) > 0 && len(validCols) > 0 {
 		maxVariant = 2
 	}
 	switch n := r.Intn(maxVariant + 2); n {
 	// case 0: // Alter column not supported in Cassandra from 3.0.11
 	//	return t.alterColumn(s.Keyspace.Name)
 	case 2:
-		colNum := r.Intn(len(t.Columns))
-		return genDropColumnStmt(t, s.Keyspace.Name, colNum)
+		num := r.Intn(len(validCols))
+		return genDropColumnStmt(t, s.Keyspace.Name, validCols[num])
 	default:
 		column := typedef.ColumnDef{Name: generators.GenColumnName("col", len(t.Columns)+1), Type: generators.GenColumnType(len(t.Columns)+1, sc)}
 		return genAddColumnStmt(t, s.Keyspace.Name, &column)

--- a/pkg/jobs/gen_ddl_stmt_test.go
+++ b/pkg/jobs/gen_ddl_stmt_test.go
@@ -30,7 +30,7 @@ var ddlDataPath = "./test_expected_data/ddl/"
 func TestGenDropColumnStmt(t *testing.T) {
 	RunStmtTest(t, path.Join(ddlDataPath, "drop_column.json"), genDropColumnStmtCases, func(subT *testing.T, caseName string, expected *expectedStore) {
 		schema, _, _, _, opts := getAllForTestStmt(subT, caseName)
-		stmt, err := genDropColumnStmt(schema.Tables[0], schema.Keyspace.Name, opts.delNum)
+		stmt, err := genDropColumnStmt(schema.Tables[0], schema.Keyspace.Name, schema.Tables[0].Columns[opts.delNum])
 		validateStmt(subT, stmt, err)
 		expected.CompareOrStore(subT, caseName, stmt)
 	})
@@ -54,7 +54,7 @@ func BenchmarkGenDropColumnStmt(t *testing.B) {
 				schema, _, _, _, opts := getAllForTestStmt(subT, caseName)
 				subT.ResetTimer()
 				for x := 0; x < subT.N; x++ {
-					_, _ = genDropColumnStmt(schema.Tables[0], schema.Keyspace.Name, opts.delNum)
+					_, _ = genDropColumnStmt(schema.Tables[0], schema.Keyspace.Name, schema.Tables[0].Columns[opts.delNum])
 				}
 			})
 	}

--- a/pkg/typedef/columns.go
+++ b/pkg/typedef/columns.go
@@ -81,11 +81,17 @@ func (c Columns) Names() []string {
 	return names
 }
 
-func (c Columns) Remove(idx int) Columns {
+func (c Columns) Remove(column *ColumnDef) Columns {
 	out := c
-	copy(out[idx:], out[idx+1:])
-	out[len(out)-1] = nil
-	return out[:len(c)-1]
+	for idx := range c {
+		if c[idx].Name == column.Name {
+			copy(out[idx:], out[idx+1:])
+			out[len(out)-1] = nil
+			out = out[:len(c)-1]
+			break
+		}
+	}
+	return out
 }
 
 func (c Columns) ToJSONMap(values map[string]interface{}, r *rand.Rand, p *PartitionRangeConfig) map[string]interface{} {

--- a/pkg/typedef/table.go
+++ b/pkg/typedef/table.go
@@ -89,19 +89,16 @@ func (t *Table) Init(s *Schema, c QueryCache) {
 	t.queryCache.BindToTable(t)
 }
 
-func (t *Table) ValidColumnsForDelete() []int {
+func (t *Table) ValidColumnsForDelete() Columns {
 	if t.Columns.Len() == 0 {
 		return nil
 	}
-	validColsLen := t.Columns.Len()
-	validCols := make([]int, 0, validColsLen)
-	for i := 0; i < validColsLen; i++ {
-		validCols = append(validCols, i)
-	}
+	validCols := make(Columns, 0, len(t.Columns))
+	validCols = append(validCols, t.Columns...)
 	if len(t.Indexes) != 0 {
 		for _, idx := range t.Indexes {
 			for j := range validCols {
-				if t.Columns[validCols[j]].Name == idx.Column {
+				if validCols[j].Name == idx.Column.Name {
 					validCols = append(validCols[:j], validCols[j+1:]...)
 					break
 				}
@@ -112,7 +109,7 @@ func (t *Table) ValidColumnsForDelete() []int {
 		for _, mv := range t.MaterializedViews {
 			if mv.HaveNonPrimaryKey() {
 				for j := range validCols {
-					if t.Columns[validCols[j]].Name == mv.NonPrimaryKey.Name {
+					if validCols[j].Name == mv.NonPrimaryKey.Name {
 						validCols = append(validCols[:j], validCols[j+1:]...)
 						break
 					}

--- a/pkg/typedef/table.go
+++ b/pkg/typedef/table.go
@@ -88,3 +88,37 @@ func (t *Table) Init(s *Schema, c QueryCache) {
 	t.queryCache = c
 	t.queryCache.BindToTable(t)
 }
+
+func (t *Table) ValidColumnsForDelete() []int {
+	if t.Columns.Len() == 0 {
+		return nil
+	}
+	validColsLen := t.Columns.Len()
+	validCols := make([]int, 0, validColsLen)
+	for i := 0; i < validColsLen; i++ {
+		validCols = append(validCols, i)
+	}
+	if len(t.Indexes) != 0 {
+		for _, idx := range t.Indexes {
+			for j := range validCols {
+				if t.Columns[validCols[j]].Name == idx.Column {
+					validCols = append(validCols[:j], validCols[j+1:]...)
+					break
+				}
+			}
+		}
+	}
+	if len(t.MaterializedViews) != 0 {
+		for _, mv := range t.MaterializedViews {
+			if mv.HaveNonPrimaryKey() {
+				for j := range validCols {
+					if t.Columns[validCols[j]].Name == mv.NonPrimaryKey.Name {
+						validCols = append(validCols[:j], validCols[j+1:]...)
+						break
+					}
+				}
+			}
+		}
+	}
+	return validCols
+}


### PR DESCRIPTION
Scylla don`t allow to drop column that is part of any materialized view primary key.
Same for column that is used in any type of index.

We need to exclude these columns from list of columns that could be deleted.