### PR TITLE
fix(SchemaConfig) Valid() - fix errors

### DIFF
--- a/pkg/typedef/errors.go
+++ b/pkg/typedef/errors.go
@@ -17,7 +17,7 @@ package typedef
 import "github.com/pkg/errors"
 
 var (
-	ErrSchemaConfigInvalidPK   = errors.New("max number of partition keys must be bigger than min number of partition keys")
-	ErrSchemaConfigInvalidCK   = errors.New("max number of clustering keys must be bigger than min number of clustering keys")
-	ErrSchemaConfigInvalidCols = errors.New("max number of columns must be bigger than min number of columns")
+	ErrSchemaConfigInvalidRangePK   = errors.New("max number of partition keys must be bigger than min number of partition keys")
+	ErrSchemaConfigInvalidRangeCK   = errors.New("max number of clustering keys must be bigger than min number of clustering keys")
+	ErrSchemaConfigInvalidRangeCols = errors.New("max number of columns must be bigger than min number of columns")
 )

--- a/pkg/typedef/schema_test.go
+++ b/pkg/typedef/schema_test.go
@@ -28,7 +28,7 @@ func TestSchemaConfigValidate(t *testing.T) {
 	}{
 		"empty": {
 			config: &SchemaConfig{},
-			want:   ErrSchemaConfigInvalidPK,
+			want:   ErrSchemaConfigInvalidRangePK,
 		},
 		"valid": {
 			config: &SchemaConfig{
@@ -46,14 +46,14 @@ func TestSchemaConfigValidate(t *testing.T) {
 				MaxPartitionKeys: 2,
 				MinPartitionKeys: 3,
 			},
-			want: ErrSchemaConfigInvalidPK,
+			want: ErrSchemaConfigInvalidRangePK,
 		},
 		"ck_missing": {
 			config: &SchemaConfig{
 				MaxPartitionKeys: 3,
 				MinPartitionKeys: 2,
 			},
-			want: ErrSchemaConfigInvalidCK,
+			want: ErrSchemaConfigInvalidRangeCK,
 		},
 		"min_ck_gt_than_max_ck": {
 			config: &SchemaConfig{
@@ -62,7 +62,7 @@ func TestSchemaConfigValidate(t *testing.T) {
 				MaxClusteringKeys: 2,
 				MinClusteringKeys: 3,
 			},
-			want: ErrSchemaConfigInvalidCK,
+			want: ErrSchemaConfigInvalidRangeCK,
 		},
 		"columns_missing": {
 			config: &SchemaConfig{
@@ -71,7 +71,7 @@ func TestSchemaConfigValidate(t *testing.T) {
 				MaxClusteringKeys: 3,
 				MinClusteringKeys: 2,
 			},
-			want: ErrSchemaConfigInvalidCols,
+			want: ErrSchemaConfigInvalidRangeCols,
 		},
 		"min_cols_gt_than_max_cols": {
 			config: &SchemaConfig{
@@ -82,7 +82,7 @@ func TestSchemaConfigValidate(t *testing.T) {
 				MaxColumns:        2,
 				MinColumns:        3,
 			},
-			want: ErrSchemaConfigInvalidCols,
+			want: ErrSchemaConfigInvalidRangeCols,
 		},
 	}
 	cmp.AllowUnexported()

--- a/pkg/typedef/schemaconfig.go
+++ b/pkg/typedef/schemaconfig.go
@@ -47,13 +47,13 @@ type SchemaConfig struct {
 
 func (sc *SchemaConfig) Valid() error {
 	if sc.MaxPartitionKeys <= sc.MinPartitionKeys {
-		return ErrSchemaConfigInvalidPK
+		return ErrSchemaConfigInvalidRangePK
 	}
 	if sc.MaxClusteringKeys <= sc.MinClusteringKeys {
-		return ErrSchemaConfigInvalidCK
+		return ErrSchemaConfigInvalidRangeCK
 	}
-	if sc.MaxColumns <= sc.MinClusteringKeys {
-		return ErrSchemaConfigInvalidCols
+	if sc.MaxColumns <= sc.MinColumns {
+		return ErrSchemaConfigInvalidRangeCols
 	}
 	return nil
 }


### PR DESCRIPTION
fixed error:
```
if sc.MaxColumns <= sc.MinClusteringKeys {
		return ErrSchemaConfigInvalidCols
	}
```
renamed errors. Sample:
ErrSchemaConfigInvalidCols >>>ErrSchemaConfigInvalidRangeCols