### PR TITLE
fix(store) add nil processing in lt function

### DIFF
--- a/pkg/store/helpers.go
+++ b/pkg/store/helpers.go
@@ -75,6 +75,8 @@ func lt(mi, mj map[string]interface{}) bool {
 	case *big.Int:
 		mjs, _ := mj["pk0"].(*big.Int)
 		return mis.Cmp(mjs) < 0
+	case nil:
+		return true
 	default:
 		msg := fmt.Sprintf("unhandled type %T\n", mis)
 		time.Sleep(time.Second)


### PR DESCRIPTION
Currently 'nil' come results panic:
```
{"L":"INFO","T":"2023-06-21T10:55:08.476-0400","N":"work cycle.validation_job","M":"Retring failed validation. 1 attempt from 10 attempts. Error: row count differ (test has 59 rows, oracle has 60 rows, test is missing rows: [pk16=45604486-11-25 23:27:42.51 +0000 UTC, \tpk17=3h50m24.065357675s, \tpk18=2130-04-03 00:00:00 +0000 UTC, \tpk19=52d8145cd62ff63, \tck=1829966953], oracle is missing rows: [])"}
{"L":"INFO","T":"2023-06-21T10:55:09.348-0400","N":"work cycle.validation_job","M":"ending validation loop"}
panic: unhandled type <nil>
```
