### PR TITLE
fix(cmd): stop generators as last to avoid deadlock on exit

### DIFF
--- a/pkg/generators/generator.go
+++ b/pkg/generators/generator.go
@@ -162,7 +162,7 @@ func (g *Generator) start() {
 			g.fillAllPartitions()
 			select {
 			case <-gCtx.Done():
-				g.logger.Debug("stopping partition key generation loop",
+				g.logger.Info("stopping partition key generation loop",
 					zap.Uint64("keys_created", g.cntCreated),
 					zap.Uint64("keys_emitted", g.cntEmitted))
 				return gCtx.Err()

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -177,7 +177,7 @@ func mutationJob(
 		}
 		select {
 		case <-ctx.Done():
-			logger.Debug("mutation job terminated")
+			logger.Info("mutation job terminated")
 			return nil
 		case hb := <-pump:
 			time.Sleep(hb)
@@ -286,7 +286,7 @@ func warmupJob(
 		}
 		select {
 		case <-ctx.Done():
-			logger.Debug("warmup job terminated")
+			logger.Info("warmup job terminated")
 			return nil
 		default:
 		}


### PR DESCRIPTION
As jobs unconditionally read from generator's channel there can be
a situation when generator is closed and will not produce
any new values while some jobs still wait on empty channel deadlocking
and preventing process exit.
