### PR TITLE
fix(generator): rework waking up generator to avoid unpredictable behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 cmd/gemini/dist/
 /gemini
 .idea
+.vscode
 bin/


### PR DESCRIPTION
Previous implementation suffers couple issues:

- It is not logical to pause generator on channel wait only when we
already know that we need more values. As in:
```
      if g.partitions.NeedMoreValues() {
              g.waitForMoreValuesNeeded()
      }
```

- Wakeup call was placed in Get() function while consumption is done in
a loop inside, in a pick() function, this can theoretically lead to a
deadlock

- Small nit: hardcoded cap(s.values)-30, in theory channel can be
smaller than 30

- When generator wakes up it fills partitions until it blocks on
a first full, this doesn't say anything about whether others
are filled or not. Especially when imbalanced situation happens
such as most partitions are full and one empty then single wake up call
has relatively small chance to fill this partition until it blocks.
Such behavior doesn't smooth out potential imbalances in channel current
lengths. In extreme cases this can lead to a situation when gemini will
not be able to generate high load on hot partition (if random behaviour
otherwise would stress such case).

- It's possible for generator goroutine to deadlock because it can be
blocked on wake up channel and in such case it won't respect context
cancellation. This doesn't have practical effect as currently no-one is
waiting for generator goroutine but if the code is used as a library
it can cause a memory leak.

Performance of new implementation is comparable to previous one.
It ma consume sligtly more cpu (i.e. 5%) due to the fact that it
strives to keep all partitions filled.
