### PR TITLE
fix(utils): generate time values in the correct range

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -42,11 +42,12 @@ func RandDate(rnd *rand.Rand) time.Time {
 	return time.Unix(rnd.Int63n(1<<63-2), rnd.Int63n(999999999)).UTC()
 }
 
-// RandTime generates time in string representation
-// it is done in such way because we wanted to make JSON statement to work
-// but scylla supports only string representation of time in JSON format
+// According to the CQL binary protocol, time is an int64 in range [0;86399999999999]
+// https://github.com/apache/cassandra/blob/f5df4b219e063cb24b9cc0c22b6e614506b8d903/doc/native_protocol_v4.spec#L941
+// An 8 byte two's complement long representing nanoseconds since midnight.
+// Valid values are in the range 0 to 86399999999999
 func RandTime(rnd *rand.Rand) int64 {
-	return rnd.Int63()
+	return rnd.Int63n(86400000000000)
 }
 
 func RandIPV4Address(rnd *rand.Rand, v, pos int) string {


### PR DESCRIPTION
The `time` CQL type represents a duration of less than 24 hours, represented as `int64_t nanoseconds`:

https://github.com/apache/cassandra/blob/f5df4b219e063cb24b9cc0c22b6e614506b8d903/doc/native_protocol_v4.spec#L941
```
6.16 time

  An 8 byte two's complement long representing nanoseconds since midnight.
  Valid values are in the range 0 to 86399999999999
```

`time` is an `int64` in range `[0;86399999999999]`, values outside of this range are invalid.

`RandTime()` generated values using `rnd.Int63()`, but this generates values outside of the allowed range.

Let's fix it so that it generates values in the correct range.

The generation of `time` values was recently modified in https://github.com/scylladb/gemini/pull/359, and `time` values have been enabled in tests, but this caused failures on Gemini runs: https://github.com/scylladb/scylladb/issues/14645

Fixes: https://github.com/scylladb/scylladb/issues/14645
Refs: https://github.com/scylladb/scylladb/issues/14667

/cc @illia-li