### PR TITLE
fix(store): add simple compare in Check function to avoid complex diff generation

### DIFF
--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"reflect"
 	"sort"
 	"sync"
 	"time"
@@ -220,6 +221,9 @@ func (ds delegatingStore) Check(ctx context.Context, table *typedef.Table, build
 		missingInOracle := strset.Difference(testSet, oracleSet).List()
 		return fmt.Errorf("row count differ (test has %d rows, oracle has %d rows, test is missing rows: %s, oracle is missing rows: %s)",
 			len(testRows), len(oracleRows), missingInTest, missingInOracle)
+	}
+	if reflect.DeepEqual(testRows, oracleRows) {
+		return nil
 	}
 	sort.SliceStable(testRows, func(i, j int) bool {
 		return lt(testRows[i], testRows[j])


### PR DESCRIPTION
Check function works extremely slow then responses has not nil data.
You can see this if compare read operations count with warmup and without warmup on same schema. It's related with fill oldValues chans during warmup.
Or if you try to force validations only with oldValues chans.
reflect.DeepEqual works up to 10 times faster that old logic with sort rows and diff generation.
And no need to sort rows and to try generate diff in cases with same testRows and oracleRows.