### PR TITLE
fix(generators): limit partitions count when size ot pk is too small

### DIFF
--- a/pkg/realrandom/source.go
+++ b/pkg/realrandom/source.go
@@ -1,0 +1,65 @@
+// Copyright 2019 ScyllaDB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realrandom
+
+import (
+	crand "crypto/rand"
+	"encoding/binary"
+	"math/bits"
+	"time"
+
+	"golang.org/x/exp/rand"
+)
+
+var Source rand.Source
+
+type crandSource struct{}
+
+func (c *crandSource) Uint64() uint64 {
+	var out [8]byte
+	_, _ = crand.Read(out[:])
+	return binary.LittleEndian.Uint64(out[:])
+}
+
+func (c *crandSource) Seed(_ uint64) {}
+
+type TimeSource struct {
+	source rand.Source
+}
+
+func NewTimeSource() *TimeSource {
+	now := time.Now()
+	return &TimeSource{
+		source: rand.NewSource(uint64(now.Nanosecond() * now.Second())),
+	}
+}
+
+func (c *TimeSource) Uint64() uint64 {
+	now := time.Now()
+	val := c.source.Uint64()
+	return bits.RotateLeft64(val^uint64(now.Nanosecond()*now.Second()), -int(val>>58))
+}
+
+func (c *TimeSource) Seed(_ uint64) {}
+
+func init() {
+	var b [8]byte
+	_, err := crand.Read(b[:])
+	if err == nil {
+		Source = &crandSource{}
+	} else {
+		Source = NewTimeSource()
+	}
+}

--- a/pkg/typedef/bag.go
+++ b/pkg/typedef/bag.go
@@ -16,11 +16,14 @@ package typedef
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"strings"
 
 	"github.com/gocql/gocql"
 	"golang.org/x/exp/rand"
+
+	"github.com/scylladb/gemini/pkg/utils"
 )
 
 type BagType struct {
@@ -79,7 +82,7 @@ func (ct *BagType) CQLPretty(query string, value []interface{}) (string, int) {
 }
 
 func (ct *BagType) GenValue(r *rand.Rand, p *PartitionRangeConfig) []interface{} {
-	count := r.Intn(9) + 1
+	count := utils.RandInt2(r, 1, maxBagSize+1)
 	out := make([]interface{}, count)
 	for i := 0; i < count; i++ {
 		out[i] = ct.ValueType.GenValue(r, p)[0]
@@ -88,7 +91,7 @@ func (ct *BagType) GenValue(r *rand.Rand, p *PartitionRangeConfig) []interface{}
 }
 
 func (ct *BagType) GenJSONValue(r *rand.Rand, p *PartitionRangeConfig) interface{} {
-	count := r.Intn(9) + 1
+	count := utils.RandInt2(r, 1, maxBagSize+1)
 	out := make([]interface{}, count)
 	for i := 0; i < count; i++ {
 		out[i] = ct.ValueType.GenJSONValue(r, p)
@@ -102,4 +105,9 @@ func (ct *BagType) LenValue() int {
 
 func (ct *BagType) Indexable() bool {
 	return false
+}
+
+// ValueVariationsNumber returns number of bytes generated value holds
+func (ct *BagType) ValueVariationsNumber(p *PartitionRangeConfig) float64 {
+	return math.Pow(ct.ValueType.ValueVariationsNumber(p), maxBagSize)
 }

--- a/pkg/typedef/columns.go
+++ b/pkg/typedef/columns.go
@@ -146,6 +146,15 @@ func (c Columns) NonCounters() Columns {
 	return out
 }
 
+// ValueVariationsNumber returns number of bytes generated value holds
+func (c Columns) ValueVariationsNumber(p *PartitionRangeConfig) float64 {
+	var out float64
+	for _, col := range c {
+		out *= col.Type.ValueVariationsNumber(p)
+	}
+	return out
+}
+
 func GetMapTypeColumn(data map[string]interface{}) (out *ColumnDef, err error) {
 	st := struct {
 		Type map[string]interface{}

--- a/pkg/typedef/interfaces.go
+++ b/pkg/typedef/interfaces.go
@@ -27,6 +27,8 @@ type Type interface {
 	GenValue(*rand.Rand, *PartitionRangeConfig) []interface{}
 	GenJSONValue(*rand.Rand, *PartitionRangeConfig) interface{}
 	LenValue() int
+	// ValueVariationsNumber returns number of bytes generated value holds
+	ValueVariationsNumber(*PartitionRangeConfig) float64
 	Indexable() bool
 	CQLType() gocql.TypeInfo
 }
@@ -37,6 +39,14 @@ func (l Types) LenValue() int {
 	out := 0
 	for _, t := range l {
 		out += t.LenValue()
+	}
+	return out
+}
+
+func (l Types) ValueVariationsNumber(p *PartitionRangeConfig) float64 {
+	var out float64
+	for _, t := range l {
+		out *= t.ValueVariationsNumber(p)
 	}
 	return out
 }

--- a/pkg/typedef/schema.go
+++ b/pkg/typedef/schema.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"strconv"
 
+	"github.com/pkg/errors"
+
 	"github.com/scylladb/gemini/pkg/murmur"
 )
 
@@ -41,6 +43,25 @@ func (s *Schema) GetHash() string {
 		panic(err)
 	}
 	return strconv.FormatUint(uint64(murmur.Murmur3H1(out)), 16)
+}
+
+func (s *Schema) Validate(distributionSize uint64) error {
+	prConfig := s.Config.GetPartitionRangeConfig()
+	for _, table := range s.Tables {
+		pkVariations := table.PartitionKeys.ValueVariationsNumber(&prConfig)
+		if pkVariations < 2^24 {
+			// On small pk size gemini stuck due to the multiple reasons, all the values could stack in inflights
+			// or partitions can become stale due to the murmur hash not hitting them, since pk low resolution
+			return errors.Errorf("pk size %d is less than gemini can handle", uint64(pkVariations))
+		}
+		if float64(distributionSize*100) > pkVariations {
+			// With low partition variations there is a chance that partition can become stale due to the
+			// murmur hash not hitting it
+			// To avoid this scenario we need to make sure that every given partition could hold at least 100 values
+			return errors.Errorf("pk size %d is less than --token-range-slices multiplied by 100", uint64(pkVariations))
+		}
+	}
+	return nil
 }
 
 func (m *MaterializedView) HaveNonPrimaryKey() bool {

--- a/pkg/typedef/simple_type.go
+++ b/pkg/typedef/simple_type.go
@@ -17,6 +17,7 @@ package typedef
 import (
 	"encoding/hex"
 	"fmt"
+	"math"
 	"math/big"
 	"net"
 	"strings"
@@ -202,13 +203,55 @@ func (st SimpleType) genValue(r *rand.Rand, p *PartitionRangeConfig) interface{}
 	case TYPE_INT:
 		return r.Int31()
 	case TYPE_SMALLINT:
-		return int16(r.Uint64n(65535))
+		return int16(r.Uint64n(65536))
 	case TYPE_TIMEUUID, TYPE_UUID:
 		return utils.UUIDFromTime(r)
 	case TYPE_TINYINT:
-		return int8(r.Uint64n(255))
+		return int8(r.Uint64n(256))
 	case TYPE_VARINT:
 		return big.NewInt(r.Int63())
+	default:
+		panic(fmt.Sprintf("generate value: not supported type %s", st))
+	}
+}
+
+// ValueVariationsNumber returns number of bytes generated value holds
+func (st SimpleType) ValueVariationsNumber(p *PartitionRangeConfig) float64 {
+	switch st {
+	case TYPE_ASCII, TYPE_TEXT, TYPE_VARCHAR:
+		return math.Pow(2, float64(p.MaxStringLength))
+	case TYPE_BLOB:
+		return math.Pow(2, float64(p.MaxBlobLength))
+	case TYPE_BIGINT:
+		return 2 ^ 64
+	case TYPE_BOOLEAN:
+		return 2
+	case TYPE_DATE:
+		return 10000*365 + 2000*4
+	case TYPE_TIME:
+		return 86400000000000
+	case TYPE_TIMESTAMP:
+		return 2 ^ 64
+	case TYPE_DECIMAL:
+		return 2 ^ 64
+	case TYPE_DOUBLE:
+		return 2 ^ 64
+	case TYPE_DURATION:
+		return 2 ^ 64
+	case TYPE_FLOAT:
+		return 2 ^ 64
+	case TYPE_INET:
+		return 2 ^ 32
+	case TYPE_INT:
+		return 2 ^ 32
+	case TYPE_SMALLINT:
+		return 2 ^ 16
+	case TYPE_TIMEUUID, TYPE_UUID:
+		return 2 ^ 64
+	case TYPE_TINYINT:
+		return 2 ^ 8
+	case TYPE_VARINT:
+		return 2 ^ 64
 	default:
 		panic(fmt.Sprintf("generate value: not supported type %s", st))
 	}

--- a/pkg/typedef/tuple.go
+++ b/pkg/typedef/tuple.go
@@ -98,3 +98,12 @@ func (t *TupleType) LenValue() int {
 	}
 	return out
 }
+
+// ValueVariationsNumber returns number of bytes generated value holds
+func (t *TupleType) ValueVariationsNumber(p *PartitionRangeConfig) float64 {
+	var out float64
+	for _, tp := range t.ValueTypes {
+		out *= out * tp.ValueVariationsNumber(p)
+	}
+	return out
+}

--- a/pkg/typedef/udt.go
+++ b/pkg/typedef/udt.go
@@ -93,3 +93,12 @@ func (t *UDTType) GenValue(r *rand.Rand, p *PartitionRangeConfig) []interface{} 
 func (t *UDTType) LenValue() int {
 	return 1
 }
+
+// ValueVariationsNumber returns number of bytes generated value holds
+func (t *UDTType) ValueVariationsNumber(p *PartitionRangeConfig) float64 {
+	var out float64
+	for _, tp := range t.ValueTypes {
+		out *= tp.ValueVariationsNumber(p)
+	}
+	return out
+}


### PR DESCRIPTION
There is a problem that leads to gemini being stuck, due to unability of generator to hit certain partitions.
It happens when partition columns size is too small for murmur to get 100% partition coverage.

There are multiple ways to fix that, but easiest is to calculate pk columns sizes and reduce partition count to match it.