### PR TITLE
fix(typedef): ValueVariationsNumber returns zero all the time

### DIFF
--- a/pkg/typedef/columns.go
+++ b/pkg/typedef/columns.go
@@ -148,7 +148,7 @@ func (c Columns) NonCounters() Columns {
 
 // ValueVariationsNumber returns number of bytes generated value holds
 func (c Columns) ValueVariationsNumber(p *PartitionRangeConfig) float64 {
-	var out float64
+	out := float64(1)
 	for _, col := range c {
 		out *= col.Type.ValueVariationsNumber(p)
 	}

--- a/pkg/typedef/interfaces.go
+++ b/pkg/typedef/interfaces.go
@@ -44,7 +44,7 @@ func (l Types) LenValue() int {
 }
 
 func (l Types) ValueVariationsNumber(p *PartitionRangeConfig) float64 {
-	var out float64
+	out := float64(1)
 	for _, t := range l {
 		out *= t.ValueVariationsNumber(p)
 	}

--- a/pkg/typedef/tuple.go
+++ b/pkg/typedef/tuple.go
@@ -101,7 +101,7 @@ func (t *TupleType) LenValue() int {
 
 // ValueVariationsNumber returns number of bytes generated value holds
 func (t *TupleType) ValueVariationsNumber(p *PartitionRangeConfig) float64 {
-	var out float64
+	out := float64(1)
 	for _, tp := range t.ValueTypes {
 		out *= out * tp.ValueVariationsNumber(p)
 	}

--- a/pkg/typedef/udt.go
+++ b/pkg/typedef/udt.go
@@ -96,7 +96,7 @@ func (t *UDTType) LenValue() int {
 
 // ValueVariationsNumber returns number of bytes generated value holds
 func (t *UDTType) ValueVariationsNumber(p *PartitionRangeConfig) float64 {
-	var out float64
+	out := float64(1)
 	for _, tp := range t.ValueTypes {
 		out *= tp.ValueVariationsNumber(p)
 	}


### PR DESCRIPTION
There is a bug in `ValueVariationsNumber` that makes it return 0 all the time.
Closes #401 