### PR TITLE
feat(cli): add statement-log-file option

### DIFF
--- a/pkg/generators/statement_generator.go
+++ b/pkg/generators/statement_generator.go
@@ -140,7 +140,7 @@ func GetCreateSchema(s *typedef.Schema) []string {
 	return stmts
 }
 
-func GetDropSchema(s *typedef.Schema) []string {
+func GetDropKeyspace(s *typedef.Schema) []string {
 	return []string{
 		fmt.Sprintf("DROP KEYSPACE IF EXISTS %s", s.Keyspace.Name),
 	}

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -329,7 +329,7 @@ func ddl(
 		if w := logger.Check(zap.DebugLevel, "ddl statement"); w != nil {
 			w.Write(zap.String("pretty_cql", ddlStmt.PrettyCQL()))
 		}
-		if err = s.Mutate(ctx, ddlStmt.Query); err != nil {
+		if err = s.Mutate(ctx, ddlStmt); err != nil {
 			if errors.Is(err, context.Canceled) {
 				return nil
 			}
@@ -376,13 +376,11 @@ func mutation(
 		}
 		return err
 	}
-	mutateQuery := mutateStmt.Query
-	mutateValues := mutateStmt.Values
 
 	if w := logger.Check(zap.DebugLevel, "mutation statement"); w != nil {
 		w.Write(zap.String("pretty_cql", mutateStmt.PrettyCQL()))
 	}
-	if err = s.Mutate(ctx, mutateQuery, mutateValues...); err != nil {
+	if err = s.Mutate(ctx, mutateStmt); err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil
 		}
@@ -425,7 +423,7 @@ func validation(
 	attempt := 1
 	for {
 		lastErr = err
-		err = s.Check(ctx, table, stmt.Query, attempt == maxAttempts, stmt.Values...)
+		err = s.Check(ctx, table, stmt, attempt == maxAttempts)
 
 		if err == nil {
 			if attempt > 1 {

--- a/pkg/stmtlogger/filelogger.go
+++ b/pkg/stmtlogger/filelogger.go
@@ -1,0 +1,135 @@
+// Copyright 2019 ScyllaDB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stmtlogger
+
+import (
+	"log"
+	"os"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/scylladb/gemini/pkg/typedef"
+)
+
+const (
+	defaultChanSize   = 1000
+	errorsOnFileLimit = 5
+)
+
+type FileLogger struct {
+	fd                   *os.File
+	activeChannel        atomic.Pointer[loggerChan]
+	channel              loggerChan
+	filename             string
+	isFileNonOperational bool
+}
+
+type loggerChan chan logRec
+
+type logRec struct {
+	stmt *typedef.Stmt
+	ts   time.Time
+}
+
+func (fl *FileLogger) LogStmt(stmt *typedef.Stmt) {
+	ch := fl.activeChannel.Load()
+	if ch != nil {
+		*ch <- logRec{
+			stmt: stmt,
+		}
+	}
+}
+
+func (fl *FileLogger) LogStmtWithTimeStamp(stmt *typedef.Stmt, ts time.Time) {
+	ch := fl.activeChannel.Load()
+	if ch != nil {
+		*ch <- logRec{
+			stmt: stmt,
+			ts:   ts,
+		}
+	}
+}
+
+func (fl *FileLogger) Close() error {
+	return fl.fd.Close()
+}
+
+func (fl *FileLogger) committer() {
+	var err2 error
+
+	defer func() {
+		fl.activeChannel.Swap(nil)
+		close(fl.channel)
+	}()
+
+	errsAtRow := 0
+
+	for rec := range fl.channel {
+		if fl.isFileNonOperational {
+			continue
+		}
+
+		_, err1 := fl.fd.Write([]byte(rec.stmt.PrettyCQL()))
+		opType := rec.stmt.QueryType.OpType()
+		if rec.ts.IsZero() || !(opType == typedef.OpInsert || opType == typedef.OpUpdate || opType == typedef.OpDelete) {
+			_, err2 = fl.fd.Write([]byte(";\n"))
+		} else {
+			_, err2 = fl.fd.Write([]byte(" USING TIMESTAMP " + strconv.FormatInt(rec.ts.UnixNano()/1000, 10) + ";\n"))
+		}
+		if err2 == nil && err1 == nil {
+			errsAtRow = 0
+			continue
+		}
+
+		if errors.Is(err2, os.ErrClosed) || errors.Is(err1, os.ErrClosed) {
+			fl.isFileNonOperational = true
+			return
+		}
+
+		errsAtRow++
+		if errsAtRow > errorsOnFileLimit {
+			fl.isFileNonOperational = true
+		}
+
+		if err2 != nil {
+			err1 = err2
+		}
+		log.Printf("failed to write to file %q: %s", fl.filename, err1)
+		return
+	}
+}
+
+func NewFileLogger(filename string) (*FileLogger, error) {
+	if filename == "" {
+		return nil, nil
+	}
+	fd, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &FileLogger{
+		filename: filename,
+		fd:       fd,
+		channel:  make(loggerChan, defaultChanSize),
+	}
+	out.activeChannel.Store(&out.channel)
+
+	go out.committer()
+	return out, nil
+}

--- a/pkg/typedef/bag.go
+++ b/pkg/typedef/bag.go
@@ -59,26 +59,20 @@ func (ct *BagType) CQLHolder() string {
 	return "?"
 }
 
-func (ct *BagType) CQLPretty(query string, value []interface{}) (string, int) {
-	if len(value) == 0 {
-		return query, 0
-	}
-	if reflect.TypeOf(value[0]).Kind() != reflect.Slice {
+func (ct *BagType) CQLPretty(value interface{}) string {
+	if reflect.TypeOf(value).Kind() != reflect.Slice {
 		panic(fmt.Sprintf("set cql pretty, unknown type %v", ct))
 	}
-	s := reflect.ValueOf(value[0])
-	op, cl := "[", "]"
+	s := reflect.ValueOf(value)
+	format := "[%s]"
 	if ct.ComplexType == TYPE_SET {
-		op, cl = "{", "}"
+		format = "{%s}"
 	}
-	vv := op
-	vv += strings.Repeat("?,", s.Len())
-	vv = strings.TrimRight(vv, ",")
-	vv += cl
+	out := make([]string, s.Len())
 	for i := 0; i < s.Len(); i++ {
-		vv, _ = ct.ValueType.CQLPretty(vv, []interface{}{s.Index(i).Interface()})
+		out[i] = ct.ValueType.CQLPretty(s.Index(i).Interface())
 	}
-	return strings.Replace(query, "?", vv, 1), 1
+	return fmt.Sprintf(format, strings.Join(out, ","))
 }
 
 func (ct *BagType) GenValue(r *rand.Rand, p *PartitionRangeConfig) []interface{} {

--- a/pkg/typedef/const.go
+++ b/pkg/typedef/const.go
@@ -36,6 +36,19 @@ const (
 	AlterColumnStatementType
 	DropColumnStatementType
 	AddColumnStatementType
+	DropKeyspaceStatementType
+	CreateKeyspaceStatementType
+	CreateSchemaStatementType
+)
+
+const (
+	OpSelect OpType = iota
+	OpInsert
+	OpUpdate
+	OpDelete
+	OpSchemaAlter
+	OpSchemaDrop
+	OpSchemaCreate
 )
 
 //nolint:revive

--- a/pkg/typedef/interfaces.go
+++ b/pkg/typedef/interfaces.go
@@ -23,7 +23,7 @@ type Type interface {
 	Name() string
 	CQLDef() string
 	CQLHolder() string
-	CQLPretty(string, []interface{}) (string, int)
+	CQLPretty(interface{}) string
 	GenValue(*rand.Rand, *PartitionRangeConfig) []interface{}
 	GenJSONValue(*rand.Rand, *PartitionRangeConfig) interface{}
 	LenValue() int

--- a/pkg/typedef/interfaces.go
+++ b/pkg/typedef/interfaces.go
@@ -33,6 +33,11 @@ type Type interface {
 	CQLType() gocql.TypeInfo
 }
 
+type Statement interface {
+	ToCql() (stmt string, names []string)
+	PrettyCQL() string
+}
+
 type Types []Type
 
 func (l Types) LenValue() int {

--- a/pkg/typedef/simple_type.go
+++ b/pkg/typedef/simple_type.go
@@ -96,9 +96,9 @@ func (st SimpleType) CQLPretty(value interface{}) string {
 		panic(fmt.Sprintf("unexpected time value [%T]%+v", value, value))
 	case TYPE_TIMESTAMP:
 		if v, ok := value.(int64); ok {
-			// CQL supports only 3 digits microseconds:
+			// CQL supports only 3 digits milliseconds:
 			// '1976-03-25T10:10:55.83275+0000': marshaling error: Milliseconds length exceeds expected (5)"
-			return time.UnixMicro(v).UTC().Format("'2006-01-02T15:04:05.999-0700'")
+			return time.UnixMilli(v).UTC().Format("'2006-01-02T15:04:05.999-0700'")
 		}
 		panic(fmt.Sprintf("unexpected timestamp value [%T]%+v", value, value))
 	case TYPE_DURATION, TYPE_TIMEUUID, TYPE_UUID:

--- a/pkg/typedef/tuple.go
+++ b/pkg/typedef/tuple.go
@@ -15,6 +15,7 @@
 package typedef
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/gocql/gocql"
@@ -54,16 +55,16 @@ func (t *TupleType) CQLHolder() string {
 	return "(" + strings.TrimRight(strings.Repeat("?,", len(t.ValueTypes)), ",") + ")"
 }
 
-func (t *TupleType) CQLPretty(query string, value []interface{}) (string, int) {
-	if len(value) == 0 {
-		return query, 0
+func (t *TupleType) CQLPretty(value interface{}) string {
+	values, ok := value.([]interface{})
+	if !ok {
+		return "()"
 	}
-	var cnt, tmp int
+	out := make([]string, len(values))
 	for i, tp := range t.ValueTypes {
-		query, tmp = tp.CQLPretty(query, value[i:])
-		cnt += tmp
+		out[i] = tp.CQLPretty(values[i])
 	}
-	return query, cnt
+	return fmt.Sprintf("(%s)", strings.Join(out, ","))
 }
 
 func (t *TupleType) Indexable() bool {

--- a/pkg/typedef/types_test.go
+++ b/pkg/typedef/types_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package typedef_test
+package typedef
 
 import (
 	"math/big"
@@ -21,142 +21,140 @@ import (
 	"time"
 
 	"gopkg.in/inf.v0"
-
-	"github.com/scylladb/gemini/pkg/typedef"
 )
 
 var millennium = time.Date(1999, 12, 31, 23, 59, 59, 0, time.UTC)
 
 var prettytests = []struct {
-	typ      typedef.Type
+	typ      Type
 	query    string
 	expected string
 	values   []interface{}
 }{
 	{
-		typ:      typedef.TYPE_ASCII,
+		typ:      TYPE_ASCII,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
 		values:   []interface{}{"a"},
 		expected: "SELECT * FROM tbl WHERE pk0='a'",
 	},
 	{
-		typ:      typedef.TYPE_BIGINT,
+		typ:      TYPE_BIGINT,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
 		values:   []interface{}{big.NewInt(10)},
 		expected: "SELECT * FROM tbl WHERE pk0=10",
 	},
 	{
-		typ:      typedef.TYPE_BLOB,
+		typ:      TYPE_BLOB,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
 		values:   []interface{}{"a"},
 		expected: "SELECT * FROM tbl WHERE pk0=textasblob('a')",
 	},
 	{
-		typ:      typedef.TYPE_BOOLEAN,
+		typ:      TYPE_BOOLEAN,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
 		values:   []interface{}{true},
 		expected: "SELECT * FROM tbl WHERE pk0=true",
 	},
 	{
-		typ:      typedef.TYPE_DATE,
+		typ:      TYPE_DATE,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
 		values:   []interface{}{millennium.Format("2006-01-02")},
 		expected: "SELECT * FROM tbl WHERE pk0='1999-12-31'",
 	},
 	{
-		typ:      typedef.TYPE_DECIMAL,
+		typ:      TYPE_DECIMAL,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
 		values:   []interface{}{inf.NewDec(1000, 0)},
 		expected: "SELECT * FROM tbl WHERE pk0=1000",
 	},
 	{
-		typ:      typedef.TYPE_DOUBLE,
+		typ:      TYPE_DOUBLE,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
 		values:   []interface{}{10.0},
 		expected: "SELECT * FROM tbl WHERE pk0=10.00",
 	},
 	{
-		typ:      typedef.TYPE_DURATION,
+		typ:      TYPE_DURATION,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
 		values:   []interface{}{10 * time.Minute},
 		expected: "SELECT * FROM tbl WHERE pk0=10m0s",
 	},
 	{
-		typ:      typedef.TYPE_FLOAT,
+		typ:      TYPE_FLOAT,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
 		values:   []interface{}{10.0},
 		expected: "SELECT * FROM tbl WHERE pk0=10.00",
 	},
 	{
-		typ:      typedef.TYPE_INET,
+		typ:      TYPE_INET,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
 		values:   []interface{}{net.ParseIP("192.168.0.1")},
 		expected: "SELECT * FROM tbl WHERE pk0='192.168.0.1'",
 	},
 	{
-		typ:      typedef.TYPE_INT,
+		typ:      TYPE_INT,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
 		values:   []interface{}{10},
 		expected: "SELECT * FROM tbl WHERE pk0=10",
 	},
 	{
-		typ:      typedef.TYPE_SMALLINT,
+		typ:      TYPE_SMALLINT,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
 		values:   []interface{}{2},
 		expected: "SELECT * FROM tbl WHERE pk0=2",
 	},
 	{
-		typ:      typedef.TYPE_TEXT,
+		typ:      TYPE_TEXT,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
 		values:   []interface{}{"a"},
 		expected: "SELECT * FROM tbl WHERE pk0='a'",
 	},
 	{
-		typ:      typedef.TYPE_TIME,
+		typ:      TYPE_TIME,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{millennium},
-		expected: "SELECT * FROM tbl WHERE pk0='" + millennium.Format(time.RFC3339) + "'",
+		values:   []interface{}{millennium.UnixNano()},
+		expected: "SELECT * FROM tbl WHERE pk0='" + millennium.Format("15:04:05.999") + "'",
 	},
 	{
-		typ:      typedef.TYPE_TIMESTAMP,
+		typ:      TYPE_TIMESTAMP,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{millennium},
-		expected: "SELECT * FROM tbl WHERE pk0='" + millennium.Format(time.RFC3339) + "'",
+		values:   []interface{}{millennium.UnixMilli()},
+		expected: "SELECT * FROM tbl WHERE pk0='" + millennium.Format("2006-01-02T15:04:05.999-0700") + "'",
 	},
 	{
-		typ:      typedef.TYPE_TIMEUUID,
+		typ:      TYPE_TIMEUUID,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
 		values:   []interface{}{"63176980-bfde-11d3-bc37-1c4d704231dc"},
 		expected: "SELECT * FROM tbl WHERE pk0=63176980-bfde-11d3-bc37-1c4d704231dc",
 	},
 	{
-		typ:      typedef.TYPE_TINYINT,
+		typ:      TYPE_TINYINT,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
 		values:   []interface{}{1},
 		expected: "SELECT * FROM tbl WHERE pk0=1",
 	},
 	{
-		typ:      typedef.TYPE_UUID,
+		typ:      TYPE_UUID,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
 		values:   []interface{}{"63176980-bfde-11d3-bc37-1c4d704231dc"},
 		expected: "SELECT * FROM tbl WHERE pk0=63176980-bfde-11d3-bc37-1c4d704231dc",
 	},
 	{
-		typ:      typedef.TYPE_VARCHAR,
+		typ:      TYPE_VARCHAR,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
 		values:   []interface{}{"a"},
 		expected: "SELECT * FROM tbl WHERE pk0='a'",
 	},
 	{
-		typ:      typedef.TYPE_VARINT,
+		typ:      TYPE_VARINT,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
 		values:   []interface{}{big.NewInt(1001)},
 		expected: "SELECT * FROM tbl WHERE pk0=1001",
 	},
 	{
-		typ: &typedef.BagType{
-			ComplexType: typedef.TYPE_SET,
-			ValueType:   typedef.TYPE_ASCII,
+		typ: &BagType{
+			ComplexType: TYPE_SET,
+			ValueType:   TYPE_ASCII,
 			Frozen:      false,
 		},
 		query:    "SELECT * FROM tbl WHERE pk0=?",
@@ -164,9 +162,9 @@ var prettytests = []struct {
 		expected: "SELECT * FROM tbl WHERE pk0={'a','b'}",
 	},
 	{
-		typ: &typedef.BagType{
-			ComplexType: typedef.TYPE_LIST,
-			ValueType:   typedef.TYPE_ASCII,
+		typ: &BagType{
+			ComplexType: TYPE_LIST,
+			ValueType:   TYPE_ASCII,
 			Frozen:      false,
 		},
 		query:    "SELECT * FROM tbl WHERE pk0=?",
@@ -174,28 +172,28 @@ var prettytests = []struct {
 		expected: "SELECT * FROM tbl WHERE pk0=['a','b']",
 	},
 	{
-		typ: &typedef.MapType{
-			KeyType:   typedef.TYPE_ASCII,
-			ValueType: typedef.TYPE_ASCII,
+		typ: &MapType{
+			KeyType:   TYPE_ASCII,
+			ValueType: TYPE_ASCII,
 			Frozen:    false,
 		},
 		query:    "SELECT * FROM tbl WHERE pk0=?",
 		values:   []interface{}{map[string]string{"a": "b"}},
-		expected: "SELECT * FROM tbl WHERE pk0={a:'b'}",
+		expected: "SELECT * FROM tbl WHERE pk0={'a':'b'}",
 	},
 	{
-		typ: &typedef.MapType{
-			KeyType:   typedef.TYPE_ASCII,
-			ValueType: typedef.TYPE_BLOB,
+		typ: &MapType{
+			KeyType:   TYPE_ASCII,
+			ValueType: TYPE_BLOB,
 			Frozen:    false,
 		},
 		query:    "SELECT * FROM tbl WHERE pk0=?",
 		values:   []interface{}{map[string]string{"a": "b"}},
-		expected: "SELECT * FROM tbl WHERE pk0={a:textasblob('b')}",
+		expected: "SELECT * FROM tbl WHERE pk0={'a':textasblob('b')}",
 	},
 	{
-		typ: &typedef.TupleType{
-			ValueTypes: []typedef.SimpleType{typedef.TYPE_ASCII},
+		typ: &TupleType{
+			ValueTypes: []SimpleType{TYPE_ASCII},
 			Frozen:     false,
 		},
 		query:    "SELECT * FROM tbl WHERE pk0=?",
@@ -203,8 +201,8 @@ var prettytests = []struct {
 		expected: "SELECT * FROM tbl WHERE pk0='a'",
 	},
 	{
-		typ: &typedef.TupleType{
-			ValueTypes: []typedef.SimpleType{typedef.TYPE_ASCII, typedef.TYPE_ASCII},
+		typ: &TupleType{
+			ValueTypes: []SimpleType{TYPE_ASCII, TYPE_ASCII},
 			Frozen:     false,
 		},
 		query:    "SELECT * FROM tbl WHERE pk0={?,?}",
@@ -216,10 +214,15 @@ var prettytests = []struct {
 func TestCQLPretty(t *testing.T) {
 	t.Parallel()
 
-	for _, p := range prettytests {
-		result := p.typ.CQLPretty(p.values)
-		if result != p.expected {
-			t.Fatalf("expected '%s', got '%s' for values %v and type '%v'", p.expected, result, p.values, p.typ)
-		}
+	for id := range prettytests {
+		test := prettytests[id]
+		t.Run(test.typ.Name(), func(t *testing.T) {
+			t.Parallel()
+
+			result := prettyCQL(test.query, test.values, []Type{test.typ})
+			if result != test.expected {
+				t.Errorf("expected '%s', got '%s' for values %v and type '%v'", test.expected, result, test.values, test.typ)
+			}
+		})
 	}
 }

--- a/pkg/typedef/types_test.go
+++ b/pkg/typedef/types_test.go
@@ -217,7 +217,7 @@ func TestCQLPretty(t *testing.T) {
 	t.Parallel()
 
 	for _, p := range prettytests {
-		result, _ := p.typ.CQLPretty(p.query, p.values)
+		result := p.typ.CQLPretty(p.values)
 		if result != p.expected {
 			t.Fatalf("expected '%s', got '%s' for values %v and type '%v'", p.expected, result, p.values, p.typ)
 		}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/exp/rand"
 )
 
-var maxDateMs = time.Date(9999, 12, 31, 0, 0, 0, 0, time.UTC).UTC().UnixMilli()
+var maxDateMs = time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC).UTC().UnixMilli()
 
 // RandDateStr generates time in string representation
 // it is done in such way because we wanted to make JSON statement to work
@@ -34,8 +34,12 @@ func RandDateStr(rnd *rand.Rand) string {
 	return time.UnixMilli(rnd.Int63n(maxDateMs)).UTC().Format("2006-01-02")
 }
 
+// RandTimestamp generates timestamp in nanoseconds
+// Date limit needed to make sure that textual representation of the date is parsable by cql and drivers
+// Currently CQL fails: unable to parse date '95260-10-10T19:09:07.148+0000': marshaling error: Unable to parse timestamp from '95260-10-10t19:09:07.148+0000'"
+// if year is bigger than 9999, same as golang time.Parse
 func RandTimestamp(rnd *rand.Rand) int64 {
-	return rnd.Int63()
+	return rnd.Int63n(maxDateMs)
 }
 
 func RandDate(rnd *rand.Rand) time.Time {


### PR DESCRIPTION
Fixes #409 

Adds option to log statements flow
Resulted file looks like:
```
DROP KEYSPACE IF EXISTS ks1;
CREATE KEYSPACE IF NOT EXISTS ks1 WITH REPLICATION = {'class':'SimpleStrategy','replication_factor':'1'};
CREATE TYPE IF NOT EXISTS ks1.udt_3644515473 (udt_3644515473_0 bigint,udt_3644515473_1 blob);
CREATE TYPE IF NOT EXISTS ks1.udt_62666315 (udt_62666315_0 inet,udt_62666315_1 boolean,udt_62666315_2 date,udt_62666315_3 float,udt_62666315_4 float,udt_62666315_5 text,udt_62666315_6 timeuuid);
CREATE TYPE IF NOT EXISTS ks1.udt_1679318000 (udt_1679318000_0 time,udt_1679318000_1 ascii,udt_1679318000_2 inet,udt_1679318000_3 smallint,udt_1679318000_4 bigint);
CREATE TABLE IF NOT EXISTS ks1.table1 (pk0 text,pk1 bigint,pk2 uuid,ck0 blob,ck1 smallint,ck2 varchar,col0 frozen<map<date,int>>,col1 tinyint,col2 frozen<udt_3644515473>,col3 blob,col4 frozen<set<uuid>>,col5 frozen<udt_62666315>,col6 frozen<udt_1679318000>,col7 float,col8 tuple<timestamp,int,varchar,time,timestamp,varchar,timestamp,uuid,timestamp,duration,timestamp,inet,double,float,tinyint,bigint,tinyint,uuid>,col9 blob,col10 frozen<tuple<float,tinyint,timestamp,duration,duration,int,timestamp,decimal,double,timeuuid,date,double,time,date,uuid,timestamp,timestamp>>, PRIMARY KEY ((pk0,pk1,pk2), ck0,ck1,ck2));
INSERT INTO ks1.table1 (pk0,pk1,pk2,ck0,ck1,ck2,col0,col1,col2,col3,col4,col5,col6,col7,col8,col9,col10) VALUES ('108ce37c8261e227dcc3dbcaa610c7fe108ce37c8261e227dcc3dbcaa610c7fe108ce37c8261e227dcc3dbcaa610c7fe108ce37c8261e227dcc3dbcaa610c7fe108ce37c8261e227dcc3dbcaa610c7fe108ce37c8261e227dcc3dbcaa610c7fe108ce37c8261e227dcc3dbcaa610c7fe108ce37c8261e227dcc3dbcaa610c7fe108ce37c8261e227dcc3dbcaa610c7fe108ce37c8261e227dcc3dbcaa610c7fe108ce37c8261e227dcc3dbcaa610c7fe108ce37c8261e227dcc3dbcaa610c7fe108ce37c8261e227dcc3dbcaa610c7fe108ce37c8261e227dcc3dbcaa610c7fe108ce37c8261e227dcc3dbcaa610c7fe108ce37c8261e227dcc3dbcaa610c7fe108ce37c8261e227dcc3dbcaa610c7fe108ce37c8261e227dcc3dbcaa610c7fe108ce37c8261e227dcc3dbcaa610c7fe108ce37c8261e227dcc3db',2662017675869867016,afa65365-0d8d-1fc9-a747-64d69a667ec0,textasblob('3962623630633064373561333864633039393361346238386563653432343964396262363063306437356133386463303939'),32384,'3627679c3b2905502be6a22bb04e97d93627679c3b2905502be6a22bb04e97d93627679c3b2905502be6a22bb04e97d93627679c3b2905502be6a22bb04e97d93627679c3b2905502be6a22bb04e97d93627679c3b290',{'5045-05-17':812309,'6636-11-09':848895449,'2015-08-25':259795404,'4542-11-25':1629586638,'4527-07-02':1592951831,'4336-01-13':754723079,'9914-10-02':2020371091},95,{udt_3644515473_0:58606650209978858,udt_3644515473_1:textasblob('3930303033653566633330623539616431663439626662383562353037383934393030303365356663333062353961643166')},textasblob('6233326132353630356165633763313832373734363234653138663330333662623332613235363035616563376331383237'),{355d9e9b-a685-1007-a7c9-64d69a667ec0,422b9c5c-43fc-15a0-a7ca-64d69a667ec0,322900a3-d24c-15e3-a7cc-64d69a667ec0},{udt_62666315_0:'117.23.254.111',udt_62666315_1:false,udt_62666315_2:'9324-09-28',udt_62666315_3:0.16,udt_62666315_4:0.18,udt_62666315_5:'374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520dc63c2ed54374f2311ca834cad01d520',udt_62666315_6:fc6f5016-0ccf-1763-a7d0-64d69a667ec0},{udt_1679318000_0:'06:22:51.768',udt_1679318000_1:'4b25189f6d202a5583201cf985ca8d1e4b25189f6d202a5583201cf985ca8d1e4b25189f6d202a5583201cf985ca8d1e4b25189f6d202a5583201cf985ca8d1e4b25189f6d202a5583201cf985ca8d1e4b25189f6d202a5583201cf985ca8d1e4b25189f6d202a5583201cf985ca8d1e4b25189f6d202a5583201cf985ca8d1e4b25189f6d202a5583201cf985ca8d1e4b25189f6d202a5583201cf985ca8d1e4b25189f6d202a5583201cf985ca8d1e4b25189f6d202a5583201cf985ca8d1e',udt_1679318000_2:'180.144.92.12',udt_1679318000_3:8870,udt_1679318000_4:1563823198671851002},0.04,('1976-03-25T10:10:55.832+0000',1173432118,'5d7d52fb0558875d31703262aae243855d7d52fb0558875d31703262aae243855d7d52fb0558875d31703262aae243855d7d52fb0558875d31703262aae243855d7d52fb0558875d31703262aae243855d7d52fb0558875d31703262aae243855d7d52fb0558875d31703262aae243855d7d52fb0558875d31703262aae243855d7d52fb0558875d31703262aae243855d7d52fb0558875d31703262aae243855d7d52fb0558875d31703262aae243855d7d52fb0558875d31703262aae243855d7d52fb0558875d31703262aae243855d7d52fb0558875d31703262aae243855d7d52fb0558875d31703262aae243855d7d52fb0558875d31703262aae243855d7d52fb0558875d31703262aae243855d7d52fb0558875d31703262aae243855d7d52fb0558875d31703','20:48:41.49','1971-07-25T21:36:58.024+0000','48753a734336db8f597985e4c7f56a4848753a734336db8f597985e4c7f56a4848753a734336db8f597985e4c7f','1976-04-11T08:22:33.559+0000',450ef95d-f01c-1754-a7d8-64d69a667ec0,'1971-08-20T23:54:52.721+0000',32m0s,'1970-09-27T11:35:00.258+0000','213.164.36.125',0.22,0.72,123,306283957986416746,39,833f8ecb-4b7a-1624-a7da-64d69a667ec0),textasblob('3438363263393637653439653463656234336238633963323766333638333538343836326339363765343965346365623433'),(0.48,-51,'1975-01-21T17:59:37.374+0000',1h25m0s,18m0s,424476374,'1973-01-28T19:56:22.084+0000',7508991256713081.973,0.71,259f28a2-0dae-17dd-a7e4-64d69a667ec0,'4795-04-25',0.12,'23:43:20.832','6660-07-17',d230ec50-f950-1199-a7e6-64d69a667ec0,'1972-12-02T18:53:19.223+0000','1970-03-06T14:17:07.658+0000'))  USING TIMESTAMP 1702961035403145;
```