### PR TITLE
fix(stmtlogger): lets gemini work with empty 'test-statement-log-file' option

### DIFF
--- a/pkg/store/cqlstore.go
+++ b/pkg/store/cqlstore.go
@@ -27,6 +27,7 @@ import (
 	"github.com/scylladb/gocqlx/v2/qb"
 	"go.uber.org/zap"
 
+	"github.com/scylladb/gemini/pkg/stmtlogger"
 	"github.com/scylladb/gemini/pkg/typedef"
 )
 
@@ -39,7 +40,7 @@ type cqlStore struct { //nolint:govet
 	maxRetriesMutate        int
 	maxRetriesMutateSleep   time.Duration
 	useServerSideTimestamps bool
-	stmtLogger              stmtLogger
+	stmtLogger              stmtlogger.StmtToFile
 }
 
 func (cs *cqlStore) name() string {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -56,12 +56,6 @@ type storeLoader interface {
 	name() string
 }
 
-type stmtLogger interface {
-	LogStmt(*typedef.Stmt)
-	LogStmtWithTimeStamp(stmt *typedef.Stmt, ts time.Time)
-	Close() error
-}
-
 type Store interface {
 	Create(context.Context, *typedef.Stmt, *typedef.Stmt) error
 	Mutate(context.Context, *typedef.Stmt) error
@@ -132,7 +126,7 @@ func (n *noOpStore) close() error {
 type delegatingStore struct {
 	oracleStore     storeLoader
 	testStore       storeLoader
-	statementLogger stmtLogger
+	statementLogger stmtlogger.StmtToFile
 	logger          *zap.Logger
 	validations     bool
 }


### PR DESCRIPTION
Empty 'test-statement-log-file' option brings to panic.
Reason:
```
func NewFileLogger(filename string) (StmtToFile, error) {
	if filename == "" {
		return nil, nil
...
```
```
func (fl *fileLogger) LogStmt(stmt *typedef.Stmt) {
	ch := fl.activeChannel.Load()
...
```