### PR TITLE
feature(materialized-views): add cli flags to disable materialized views

### DIFF
--- a/cmd/gemini/root.go
+++ b/cmd/gemini/root.go
@@ -85,6 +85,7 @@ var (
 	minColumns                       int
 	datasetSize                      string
 	cqlFeatures                      string
+	useMaterializedViews             bool
 	level                            string
 	maxRetriesMutate                 int
 	maxRetriesMutateSleep            time.Duration
@@ -496,6 +497,7 @@ func init() {
 	rootCmd.Flags().IntVarP(&minColumns, "min-columns", "", 8, "Minimum number of generated columns")
 	rootCmd.Flags().StringVarP(&datasetSize, "dataset-size", "", "large", "Specify the type of dataset size to use, small|large")
 	rootCmd.Flags().StringVarP(&cqlFeatures, "cql-features", "", "basic", "Specify the type of cql features to use, basic|normal|all")
+	rootCmd.Flags().BoolVarP(&useMaterializedViews, "materialized-views", "", false, "Run gemini with materialized views support")
 	rootCmd.Flags().StringVarP(&level, "level", "", "info", "Specify the logging level, debug|info|warn|error|dpanic|panic|fatal")
 	rootCmd.Flags().IntVarP(&maxRetriesMutate, "max-mutation-retries", "", 2, "Maximum number of attempts to apply a mutation")
 	rootCmd.Flags().DurationVarP(

--- a/cmd/gemini/schema.go
+++ b/cmd/gemini/schema.go
@@ -47,6 +47,7 @@ func createSchemaConfig(logger *zap.Logger) typedef.SchemaConfig {
 			UseLWT:                           defaultConfig.UseLWT,
 			CQLFeature:                       defaultConfig.CQLFeature,
 			AsyncObjectStabilizationAttempts: defaultConfig.AsyncObjectStabilizationAttempts,
+			UseMaterializedViews:             defaultConfig.UseMaterializedViews,
 			AsyncObjectStabilizationDelay:    defaultConfig.AsyncObjectStabilizationDelay,
 		}
 	default:
@@ -85,6 +86,7 @@ func createDefaultSchemaConfig(logger *zap.Logger) typedef.SchemaConfig {
 		UseCounters:                      useCounters,
 		UseLWT:                           useLWT,
 		CQLFeature:                       getCQLFeature(cqlFeatures),
+		UseMaterializedViews:             useMaterializedViews,
 		AsyncObjectStabilizationAttempts: asyncObjectStabilizationAttempts,
 		AsyncObjectStabilizationDelay:    asyncObjectStabilizationDelay,
 	}

--- a/pkg/generators/statement_generator.go
+++ b/pkg/generators/statement_generator.go
@@ -87,7 +87,7 @@ func genTable(sc typedef.SchemaConfig, tableName string, r *rand.Rand) *typedef.
 	table.Indexes = indexes
 
 	var mvs []typedef.MaterializedView
-	if sc.CQLFeature > typedef.CQL_FEATURE_BASIC && len(clusteringKeys) > 0 && columns.ValidColumnsForPrimaryKey().Len() != 0 {
+	if sc.CQLFeature > typedef.CQL_FEATURE_BASIC && sc.UseMaterializedViews && len(clusteringKeys) > 0 && columns.ValidColumnsForPrimaryKey().Len() != 0 {
 		mvs = CreateMaterializedViews(columns, table.Name, partitionKeys, clusteringKeys, r)
 	}
 

--- a/pkg/typedef/schemaconfig.go
+++ b/pkg/typedef/schemaconfig.go
@@ -40,6 +40,7 @@ type SchemaConfig struct {
 	MinStringLength                  int
 	UseCounters                      bool
 	UseLWT                           bool
+	UseMaterializedViews             bool
 	CQLFeature                       CQLFeature
 	AsyncObjectStabilizationAttempts int
 	AsyncObjectStabilizationDelay    time.Duration


### PR DESCRIPTION
There is a crash in gemini, which is deeped then we expected first, and it comes down to the materialized views generation and validation. Something there is wrong, until further investigation (and possibly gemini redisign, this issue cannot be fixed). As I've discussed with @fruch about this issue, we concluded that the best way forward for now is to disable materialized views until the redisign of the project.

Simplest solution is just to add the CLI flag and propagate it to the creation of the materialized views.

Jenkins Issue: https://jenkins.scylladb.com/job/enterprise-2024.1/job/gemini-/job/gemini-3h-with-nemesis-test/27/
