### PR TITLE
feature(ci): release gemini using goreleaser and github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+  packages: write
+  issues: write
+  id-token: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to dockerhub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "v2.3.1"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,12 +22,6 @@ checksum:
 snapshot:
   name_template: "{{ .Tag }}-next"
 
-blobs:
-  - provider: s3
-    bucket: downloads.scylladb.com
-    region: us-east-1
-    folder: "gemini/{{.Version}}"
-
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
In order to make use of goreleaser, we need GitHub Action to build and `gemini` and generate changelog

This is the action to do so. 

## Commented out `blob`

Inside the repository, we don't have any AWS Keys to upload gemini binaries to S3 Bucket. until that gets sorted out, it is better to leave it commented and have the gemini release as soon as possible to test the #424 in SCT.