### PR TITLE
improvement(go1.23): use any instead of inteface{}

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ $(GOBIN)/golangci-lint: GOLANGCI_VERSION = 1.60.3
 $(GOBIN)/golangci-lint: Makefile
 	$(call dl_tgz,golangci-lint,https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCI_VERSION)/golangci-lint-$(GOLANGCI_VERSION)-$(GOOS)-amd64.tar.gz)
 
+.PHONY: fmt
+fmt:
+	gofumpt -w -extra .
+
 .PHONY: check
 check: $(GOBIN)/golangci-lint
 	$(GOBIN)/golangci-lint run

--- a/cmd/gemini/spinner.go
+++ b/cmd/gemini/spinner.go
@@ -25,7 +25,7 @@ type spinningFeedback struct {
 	s *spinner.Spinner
 }
 
-func (sf *spinningFeedback) Set(format string, args ...interface{}) {
+func (sf *spinningFeedback) Set(format string, args ...any) {
 	if sf.s != nil {
 		sf.s.Suffix = fmt.Sprintf(format, args...)
 	}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,7 +56,7 @@ in use but the idea is to introduce some jitter into the execution flow.
 The application generates partition ids through a `Generator` that creates a steady flow of partition
 key components for the desired [concurrency](architecture.md#Concurrency).
 Each goroutine is connected to a `partition` that the generator controls. This partition continuously emits
-new partition ids in the form of a `[]interface{}`. These keys are created in the same way as the the
+new partition ids in the form of a `[]any`. These keys are created in the same way as the the
 driver does to ensure that each goroutine only processes partition keys from it's designated bucket.
 These partition keys These values are copied into another list that keeps the old partition ids for
 later reuse. The idea of reusing the partition keys is that probability of hitting the same partition

--- a/pkg/generators/utils.go
+++ b/pkg/generators/utils.go
@@ -20,8 +20,8 @@ import (
 	"github.com/scylladb/gemini/pkg/typedef"
 )
 
-func CreatePartitionKeyValues(table *typedef.Table, r *rand.Rand, g *typedef.PartitionRangeConfig) []interface{} {
-	values := make([]interface{}, 0, table.PartitionKeysLenValues())
+func CreatePartitionKeyValues(table *typedef.Table, r *rand.Rand, g *typedef.PartitionRangeConfig) []any {
+	values := make([]any, 0, table.PartitionKeysLenValues())
 	for _, pk := range table.PartitionKeys {
 		values = append(values, pk.Type.GenValue(r, g)...)
 	}

--- a/pkg/inflight/inflight_test.go
+++ b/pkg/inflight/inflight_test.go
@@ -69,10 +69,10 @@ func TestDeleteSharded(t *testing.T) {
 func TestInflight(t *testing.T) {
 	t.Parallel()
 	flight := newSyncU64set(shrinkInflightsLimit)
-	f := func(v uint64) interface{} {
+	f := func(v uint64) any {
 		return flight.AddIfNotPresent(v)
 	}
-	g := func(v uint64) interface{} {
+	g := func(v uint64) any {
 		flight.Delete(v)
 		return !flight.Has(v)
 	}
@@ -105,10 +105,10 @@ func TestAutoShrink(t *testing.T) {
 func TestInflightSharded(t *testing.T) {
 	t.Parallel()
 	flight := newShardedSyncU64set()
-	f := func(v uint64) interface{} {
+	f := func(v uint64) any {
 		return flight.AddIfNotPresent(v)
 	}
-	g := func(v uint64) interface{} {
+	g := func(v uint64) any {
 		flight.Delete(v)
 		return !flight.shards[v%256].Has(v)
 	}

--- a/pkg/joberror/joberror_test.go
+++ b/pkg/joberror/joberror_test.go
@@ -33,7 +33,7 @@ func TestParallel(t *testing.T) {
 	wg := sync.WaitGroup{}
 	resultList := joberror.NewErrorList(1000)
 	expectedList := joberror.NewErrorList(1000)
-	baseDate := time.Date(2020, 02, 01, 0, 0, 0, 0, time.UTC)
+	baseDate := time.Date(2020, 0o2, 0o1, 0, 0, 0, 0, time.UTC)
 	idx := atomic.Int32{}
 	for y := 0; y < 1000; y++ {
 		expectedList.AddError(&joberror.JobError{
@@ -73,7 +73,7 @@ func TestErrorSerialization(t *testing.T) {
 	t.Parallel()
 	expected := []byte(`{"timestamp":"2020-02-01T00:00:00Z","message":"Some Message","query":"Some Query","stmt-type":"Some Type"}`)
 	result, err := json.Marshal(joberror.JobError{
-		Timestamp: time.Date(2020, 02, 01, 0, 0, 0, 0, time.UTC),
+		Timestamp: time.Date(2020, 0o2, 0o1, 0, 0, 0, 0, time.UTC),
 		Message:   "Some Message",
 		Query:     "Some Query",
 		StmtType:  "Some Type",
@@ -92,7 +92,7 @@ func TestErrorListSerialization(t *testing.T) {
 	//nolint:lll
 	expected := []byte(`[{"timestamp":"2020-02-01T00:00:00Z","message":"Some Message 0","query":"Some Query 0","stmt-type":"Some Stmt Type 0"},{"timestamp":"2020-02-02T00:00:00Z","message":"Some Message 1","query":"Some Query 1","stmt-type":"Some Stmt Type 1"},{"timestamp":"2020-02-03T00:00:00Z","message":"Some Message 2","query":"Some Query 2","stmt-type":"Some Stmt Type 2"},{"timestamp":"2020-02-04T00:00:00Z","message":"Some Message 3","query":"Some Query 3","stmt-type":"Some Stmt Type 3"},{"timestamp":"2020-02-05T00:00:00Z","message":"Some Message 4","query":"Some Query 4","stmt-type":"Some Stmt Type 4"},{"timestamp":"2020-02-06T00:00:00Z","message":"Some Message 5","query":"Some Query 5","stmt-type":"Some Stmt Type 5"},{"timestamp":"2020-02-07T00:00:00Z","message":"Some Message 6","query":"Some Query 6","stmt-type":"Some Stmt Type 6"},{"timestamp":"2020-02-08T00:00:00Z","message":"Some Message 7","query":"Some Query 7","stmt-type":"Some Stmt Type 7"},{"timestamp":"2020-02-09T00:00:00Z","message":"Some Message 8","query":"Some Query 8","stmt-type":"Some Stmt Type 8"},{"timestamp":"2020-02-10T00:00:00Z","message":"Some Message 9","query":"Some Query 9","stmt-type":"Some Stmt Type 9"}]`)
 	lst := joberror.NewErrorList(1000)
-	baseDate := time.Date(2020, 02, 01, 0, 0, 0, 0, time.UTC)
+	baseDate := time.Date(2020, 0o2, 0o1, 0, 0, 0, 0, time.UTC)
 	for y := 0; y < 10; y++ {
 		lst.AddError(&joberror.JobError{
 			Timestamp: baseDate.AddDate(0, 0, y),

--- a/pkg/jobs/gen_check_stmt.go
+++ b/pkg/jobs/gen_check_stmt.go
@@ -165,7 +165,7 @@ func genSinglePartitionQueryMv(
 
 	values := valuesWithToken.Value.Copy()
 	if mv.HaveNonPrimaryKey() {
-		var mvValues []interface{}
+		var mvValues []any
 		mvValues = append(mvValues, mv.NonPrimaryKey.Type.GenValue(r, p)...)
 		values = append(mvValues, values...)
 	}
@@ -189,7 +189,7 @@ func genMultiplePartitionQuery(
 	t.RLock()
 	defer t.RUnlock()
 	typs := make([]typedef.Type, numQueryPKs*t.PartitionKeys.Len())
-	values := make([]interface{}, numQueryPKs*t.PartitionKeys.Len())
+	values := make([]any, numQueryPKs*t.PartitionKeys.Len())
 
 	builder := qb.Select(s.Keyspace.Name + "." + t.Name)
 	tokens := make([]*typedef.ValueWithToken, 0, numQueryPKs)
@@ -233,7 +233,7 @@ func genMultiplePartitionQueryMv(
 
 	mv := t.MaterializedViews[mvNum]
 	typs := make([]typedef.Type, numQueryPKs*mv.PartitionKeys.Len())
-	values := make([]interface{}, numQueryPKs*mv.PartitionKeys.Len())
+	values := make([]any, numQueryPKs*mv.PartitionKeys.Len())
 
 	builder := qb.Select(s.Keyspace.Name + "." + t.Name)
 	tokens := make([]*typedef.ValueWithToken, 0, numQueryPKs)
@@ -245,7 +245,7 @@ func genMultiplePartitionQueryMv(
 			return nil
 		}
 		tokens = append(tokens, vs)
-		vals := make([]interface{}, mv.PartitionKeys.Len())
+		vals := make([]any, mv.PartitionKeys.Len())
 		if mv.HaveNonPrimaryKey() {
 			vals[0] = mv.NonPrimaryKey.Type.GenValue(r, p)
 			copy(vals[1:], vs.Value.Copy())
@@ -335,7 +335,7 @@ func genClusteringRangeQueryMv(
 	values := vs.Value.Copy()
 	mv := t.MaterializedViews[mvNum]
 	if mv.HaveNonPrimaryKey() {
-		mvValues := append([]interface{}{}, mv.NonPrimaryKey.Type.GenValue(r, p)...)
+		mvValues := append([]any{}, mv.NonPrimaryKey.Type.GenValue(r, p)...)
 		values = append(mvValues, values...)
 	}
 	builder := qb.Select(s.Keyspace.Name + "." + mv.Name)
@@ -525,7 +525,7 @@ func genSingleIndexQuery(
 	defer t.RUnlock()
 
 	var (
-		values []interface{}
+		values []any
 		typs   []typedef.Type
 	)
 

--- a/pkg/jobs/gen_ddl_stmt.go
+++ b/pkg/jobs/gen_ddl_stmt.go
@@ -45,7 +45,7 @@ func GenDDLStmt(s *typedef.Schema, t *typedef.Table, r *rand.Rand, _ *typedef.Pa
 	}
 }
 
-func appendValue(columnType typedef.Type, r *rand.Rand, p *typedef.PartitionRangeConfig, values []interface{}) []interface{} {
+func appendValue(columnType typedef.Type, r *rand.Rand, p *typedef.PartitionRangeConfig, values []any) []any {
 	return append(values, columnType.GenValue(r, p)...)
 }
 

--- a/pkg/jobs/gen_mutate_stmt.go
+++ b/pkg/jobs/gen_mutate_stmt.go
@@ -129,13 +129,13 @@ func genInsertJSONStmt(
 		return nil, nil
 	}
 	vs := valuesWithToken.Value.Copy()
-	values := make(map[string]interface{})
+	values := make(map[string]any)
 	for i, pk := range table.PartitionKeys {
 		switch t := pk.Type.(type) {
 		case typedef.SimpleType:
 			values[pk.Name] = convertForJSON(t, vs[i])
 		case *typedef.TupleType:
-			tupVals := make([]interface{}, len(t.ValueTypes))
+			tupVals := make([]any, len(t.ValueTypes))
 			for j := 0; j < len(t.ValueTypes); j++ {
 				tupVals[i] = convertForJSON(t, vs[i])
 				i++
@@ -161,7 +161,7 @@ func genInsertJSONStmt(
 			QueryType: typedef.InsertJSONStatementType,
 		},
 		ValuesWithToken: []*typedef.ValueWithToken{valuesWithToken},
-		Values:          []interface{}{string(jsonString)},
+		Values:          []any{string(jsonString)},
 	}, nil
 }
 
@@ -180,7 +180,7 @@ func genDeleteRows(_ *typedef.Schema, t *typedef.Table, valuesWithToken *typedef
 	}, nil
 }
 
-func convertForJSON(vType typedef.Type, value interface{}) interface{} {
+func convertForJSON(vType typedef.Type, value any) any {
 	switch vType {
 	case typedef.TYPE_BLOB:
 		val, _ := value.(string)

--- a/pkg/jobs/gen_utils_test.go
+++ b/pkg/jobs/gen_utils_test.go
@@ -151,7 +151,7 @@ func (r results) Diff(t results) string {
 	return strings.Join(out, "\n")
 }
 
-func convertStmtsToResults(stmt interface{}) results {
+func convertStmtsToResults(stmt any) results {
 	var out results
 	switch stmts := stmt.(type) {
 	case *typedef.Stmts:
@@ -239,7 +239,7 @@ func GetCkCountFromOptions(options testutils.TestCaseOptions, allValue int) int 
 	return ckCount
 }
 
-func validateStmt(t *testing.T, stmt interface{}, err error) {
+func validateStmt(t *testing.T, stmt any, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("error: get an error on create test inputs:%v", err)

--- a/pkg/replication/replication.go
+++ b/pkg/replication/replication.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 )
 
-type Replication map[string]interface{}
+type Replication map[string]any
 
 func (r *Replication) ToCQL() string {
 	b, _ := json.Marshal(r)
@@ -41,7 +41,7 @@ func NewNetworkTopologyStrategy() *Replication {
 }
 
 func (r *Replication) UnmarshalJSON(data []byte) error {
-	dataMap := make(map[string]interface{})
+	dataMap := make(map[string]any)
 	if err := json.Unmarshal(data, &dataMap); err != nil {
 		return err
 	}

--- a/pkg/routingkey/routing_key.go
+++ b/pkg/routingkey/routing_key.go
@@ -28,7 +28,7 @@ type Creator struct {
 	routingKeyBuffer []byte
 }
 
-func (rc *Creator) CreateRoutingKey(table *typedef.Table, values []interface{}) ([]byte, error) {
+func (rc *Creator) CreateRoutingKey(table *typedef.Table, values []any) ([]byte, error) {
 	partitionKeys := table.PartitionKeys
 	if len(partitionKeys) == 1 {
 		// single column routing key

--- a/pkg/routingkey/routing_key_test.go
+++ b/pkg/routingkey/routing_key_test.go
@@ -44,231 +44,231 @@ func TestRoutingKey(t *testing.T) {
 			},
 			data: []data{
 				{
-					values: []interface{}{1641072984},
+					values: []any{1641072984},
 					want:   decodeHex("61d0c958"),
 				},
 				{
-					values: []interface{}{1904972303},
+					values: []any{1904972303},
 					want:   decodeHex("718b920f"),
 				},
 				{
-					values: []interface{}{1236194666},
+					values: []any{1236194666},
 					want:   decodeHex("49aed56a"),
 				},
 				{
-					values: []interface{}{2095188122},
+					values: []any{2095188122},
 					want:   decodeHex("7ce2089a"),
 				},
 				{
-					values: []interface{}{45882928},
+					values: []any{45882928},
 					want:   decodeHex("02bc1e30"),
 				},
 				{
-					values: []interface{}{1057932065},
+					values: []any{1057932065},
 					want:   decodeHex("3f0ec321"),
 				},
 				{
-					values: []interface{}{1236194666},
+					values: []any{1236194666},
 					want:   decodeHex("49aed56a"),
 				},
 				{
-					values: []interface{}{812457792},
+					values: []any{812457792},
 					want:   decodeHex("306d1f40"),
 				},
 				{
-					values: []interface{}{1334454052},
+					values: []any{1334454052},
 					want:   decodeHex("4f8a2724"),
 				},
 				{
-					values: []interface{}{45882928},
+					values: []any{45882928},
 					want:   decodeHex("02bc1e30"),
 				},
 				{
-					values: []interface{}{1904972303},
+					values: []any{1904972303},
 					want:   decodeHex("718b920f"),
 				},
 				{
-					values: []interface{}{368842197},
+					values: []any{368842197},
 					want:   decodeHex("15fc15d5"),
 				},
 				{
-					values: []interface{}{2095188122},
+					values: []any{2095188122},
 					want:   decodeHex("7ce2089a"),
 				},
 				{
-					values: []interface{}{475379656},
+					values: []any{475379656},
 					want:   decodeHex("1c55b7c8"),
 				},
 				{
-					values: []interface{}{1641072984},
+					values: []any{1641072984},
 					want:   decodeHex("61d0c958"),
 				},
 				{
-					values: []interface{}{904957324},
+					values: []any{904957324},
 					want:   decodeHex("35f08d8c"),
 				},
 				{
-					values: []interface{}{262309475},
+					values: []any{262309475},
 					want:   decodeHex("0fa28663"),
 				},
 				{
-					values: []interface{}{1227835653},
+					values: []any{1227835653},
 					want:   decodeHex("492f4905"),
 				},
 				{
-					values: []interface{}{1425448500},
+					values: []any{1425448500},
 					want:   decodeHex("54f69e34"),
 				},
 				{
-					values: []interface{}{597709428},
+					values: []any{597709428},
 					want:   decodeHex("23a05274"),
 				},
 				{
-					values: []interface{}{1800248233},
+					values: []any{1800248233},
 					want:   decodeHex("6b4d9ba9"),
 				},
 				{
-					values: []interface{}{806697938},
+					values: []any{806697938},
 					want:   decodeHex("30153bd2"),
 				},
 				{
-					values: []interface{}{2086829109},
+					values: []any{2086829109},
 					want:   decodeHex("7c627c35"),
 				},
 				{
-					values: []interface{}{1630944338},
+					values: []any{1630944338},
 					want:   decodeHex("61363c52"),
 				},
 				{
-					values: []interface{}{168212700},
+					values: []any{168212700},
 					want:   decodeHex("0a06b8dc"),
 				},
 				{
-					values: []interface{}{168212700},
+					values: []any{168212700},
 					want:   decodeHex("0a06b8dc"),
 				},
 				{
-					values: []interface{}{2086829109},
+					values: []any{2086829109},
 					want:   decodeHex("7c627c35"),
 				},
 				{
-					values: []interface{}{1800248233},
+					values: []any{1800248233},
 					want:   decodeHex("6b4d9ba9"),
 				},
 				{
-					values: []interface{}{904957324},
+					values: []any{904957324},
 					want:   decodeHex("35f08d8c"),
 				},
 				{
-					values: []interface{}{806697938},
+					values: []any{806697938},
 					want:   decodeHex("30153bd2"),
 				},
 				{
-					values: []interface{}{1425448500},
+					values: []any{1425448500},
 					want:   decodeHex("54f69e34"),
 				},
 				{
-					values: []interface{}{1227835653},
+					values: []any{1227835653},
 					want:   decodeHex("492f4905"),
 				},
 				{
-					values: []interface{}{597709428},
+					values: []any{597709428},
 					want:   decodeHex("23a05274"),
 				},
 				{
-					values: []interface{}{1630944338},
+					values: []any{1630944338},
 					want:   decodeHex("61363c52"),
 				},
 				{
-					values: []interface{}{262309475},
+					values: []any{262309475},
 					want:   decodeHex("0fa28663"),
 				},
 				{
-					values: []interface{}{1121302931},
+					values: []any{1121302931},
 					want:   decodeHex("42d5b993"),
 				},
 				{
-					values: []interface{}{1683526033},
+					values: []any{1683526033},
 					want:   decodeHex("64589191"),
 				},
 				{
-					values: []interface{}{413686973},
+					values: []any{413686973},
 					want:   decodeHex("18a85cbd"),
 				},
 				{
-					values: []interface{}{1768299632},
+					values: []any{1768299632},
 					want:   decodeHex("69661c70"),
 				},
 				{
-					values: []interface{}{798338925},
+					values: []any{798338925},
 					want:   decodeHex("2f95af6d"),
 				},
 				{
-					values: []interface{}{1499238155},
+					values: []any{1499238155},
 					want:   decodeHex("595c8f0b"),
 				},
 				{
-					values: []interface{}{162452846},
+					values: []any{162452846},
 					want:   decodeHex("09aed56e"),
 				},
 				{
-					values: []interface{}{995951772},
+					values: []any{995951772},
 					want:   decodeHex("3b5d049c"),
 				},
 				{
-					values: []interface{}{591949574},
+					values: []any{591949574},
 					want:   decodeHex("23486f06"),
 				},
 				{
-					values: []interface{}{1980296387},
+					values: []any{1980296387},
 					want:   decodeHex("7608ecc3"),
 				},
 				{
-					values: []interface{}{1980296387},
+					values: []any{1980296387},
 					want:   decodeHex("7608ecc3"),
 				},
 				{
-					values: []interface{}{798338925},
+					values: []any{798338925},
 					want:   decodeHex("2f95af6d"),
 				},
 				{
-					values: []interface{}{1121302931},
+					values: []any{1121302931},
 					want:   decodeHex("42d5b993"),
 				},
 				{
-					values: []interface{}{1499238155},
+					values: []any{1499238155},
 					want:   decodeHex("595c8f0b"),
 				},
 				{
-					values: []interface{}{162452846},
+					values: []any{162452846},
 					want:   decodeHex("09aed56e"),
 				},
 				{
-					values: []interface{}{413686973},
+					values: []any{413686973},
 					want:   decodeHex("18a85cbd"),
 				},
 				{
-					values: []interface{}{1683526033},
+					values: []any{1683526033},
 					want:   decodeHex("64589191"),
 				},
 				{
-					values: []interface{}{1768299632},
+					values: []any{1768299632},
 					want:   decodeHex("69661c70"),
 				},
 				{
-					values: []interface{}{995951772},
+					values: []any{995951772},
 					want:   decodeHex("3b5d049c"),
 				},
 				{
-					values: []interface{}{591949574},
+					values: []any{591949574},
 					want:   decodeHex("23486f06"),
 				},
 				{
-					values: []interface{}{1417141266},
+					values: []any{1417141266},
 					want:   decodeHex("5477dc12"),
 				},
 				{
-					values: []interface{}{1417141266},
+					values: []any{1417141266},
 					want:   decodeHex("5477dc12"),
 				},
 			},
@@ -280,183 +280,183 @@ func TestRoutingKey(t *testing.T) {
 			},
 			data: []data{
 				{
-					values: []interface{}{154109775, 10044141},
+					values: []any{154109775, 10044141},
 					want:   decodeHex("0004092f874f000004009942ed00"),
 				},
 				{
-					values: []interface{}{1313258788, 1466181868},
+					values: []any{1313258788, 1466181868},
 					want:   decodeHex("00044e46bd24000004576428ec00"),
 				},
 				{
-					values: []interface{}{287541659, 266079166},
+					values: []any{287541659, 266079166},
 					want:   decodeHex("00041123899b0000040fdc0bbe00"),
 				},
 				{
-					values: []interface{}{1555318302, 1661168631},
+					values: []any{1555318302, 1661168631},
 					want:   decodeHex("00045cb4461e00000463036bf700"),
 				},
 				{
-					values: []interface{}{441838458, 453773327},
+					values: []any{441838458, 453773327},
 					want:   decodeHex("00041a55eb7a0000041b0c080f00"),
 				},
 				{
-					values: []interface{}{876168687, 910346726},
+					values: []any{876168687, 910346726},
 					want:   decodeHex("0004343945ef0000043642c9e600"),
 				},
 				{
-					values: []interface{}{682056909, 682069788},
+					values: []any{682056909, 682069788},
 					want:   decodeHex("000428a75ccd00000428a78f1c00"),
 				},
 				{
-					values: []interface{}{1099404621, 1260277606},
+					values: []any{1099404621, 1260277606},
 					want:   decodeHex("00044187954d0000044b1e4f6600"),
 				},
 				{
-					values: []interface{}{48146003, 72800984},
+					values: []any{48146003, 72800984},
 					want:   decodeHex("000402dea6530000040456dad800"),
 				},
 				{
-					values: []interface{}{1045015705, 1017672610},
+					values: []any{1045015705, 1017672610},
 					want:   decodeHex("00043e49ac990000043ca873a200"),
 				},
 				{
-					values: []interface{}{1338382691, 1378061000},
+					values: []any{1338382691, 1378061000},
 					want:   decodeHex("00044fc6196300000452238ac800"),
 				},
 				{
-					values: []interface{}{441838458, 453773327},
+					values: []any{441838458, 453773327},
 					want:   decodeHex("00041a55eb7a0000041b0c080f00"),
 				},
 				{
-					values: []interface{}{1555318302, 1661168631},
+					values: []any{1555318302, 1661168631},
 					want:   decodeHex("00045cb4461e00000463036bf700"),
 				},
 				{
-					values: []interface{}{287541659, 266079166},
+					values: []any{287541659, 266079166},
 					want:   decodeHex("00041123899b0000040fdc0bbe00"),
 				},
 				{
-					values: []interface{}{1085821086, 1230891834},
+					values: []any{1085821086, 1230891834},
 					want:   decodeHex("000440b8509e000004495deb3a00"),
 				},
 				{
-					values: []interface{}{2118757525, 2091414430},
+					values: []any{2118757525, 2091414430},
 					want:   decodeHex("00047e49ac950000047ca8739e00"),
 				},
 				{
-					values: []interface{}{723092642, 797106325},
+					values: []any{723092642, 797106325},
 					want:   decodeHex("00042b1984a20000042f82e09500"),
 				},
 				{
-					values: []interface{}{1900826555, 1739648564},
+					values: []any{1900826555, 1739648564},
 					want:   decodeHex("0004714c4fbb00000467b0ee3400"),
 				},
 				{
-					values: []interface{}{48146003, 72800984},
+					values: []any{48146003, 72800984},
 					want:   decodeHex("000402dea6530000040456dad800"),
 				},
 				{
-					values: []interface{}{1338382691, 1378061000},
+					values: []any{1338382691, 1378061000},
 					want:   decodeHex("00044fc6196300000452238ac800"),
 				},
 				{
-					values: []interface{}{1045015705, 1017672610},
+					values: []any{1045015705, 1017672610},
 					want:   decodeHex("00043e49ac990000043ca873a200"),
 				},
 				{
-					values: []interface{}{290624561, 281368602},
+					values: []any{290624561, 281368602},
 					want:   decodeHex("00041152943100000410c5581a00"),
 				},
 				{
-					values: []interface{}{1628942696, 1544546792},
+					values: []any{1628942696, 1544546792},
 					want:   decodeHex("00046117b1680000045c0fe9e800"),
 				},
 				{
-					values: []interface{}{439094547, 457987688},
+					values: []any{439094547, 457987688},
 					want:   decodeHex("00041a2c0d130000041b4c566800"),
 				},
 				{
-					values: []interface{}{1085821086, 1230891834},
+					values: []any{1085821086, 1230891834},
 					want:   decodeHex("000440b8509e000004495deb3a00"),
 				},
 				{
-					values: []interface{}{2118757525, 2091414430},
+					values: []any{2118757525, 2091414430},
 					want:   decodeHex("00047e49ac950000047ca8739e00"),
 				},
 				{
-					values: []interface{}{55214822, 972879},
+					values: []any{55214822, 972879},
 					want:   decodeHex("0004034a82e6000004000ed84f00"),
 				},
 				{
-					values: []interface{}{723092642, 797106325},
+					values: []any{723092642, 797106325},
 					want:   decodeHex("00042b1984a20000042f82e09500"),
 				},
 				{
-					values: []interface{}{1900826555, 1739648564},
+					values: []any{1900826555, 1739648564},
 					want:   decodeHex("0004714c4fbb00000467b0ee3400"),
 				},
 				{
-					values: []interface{}{1307654654, 1374426858},
+					values: []any{1307654654, 1374426858},
 					want:   decodeHex("00044df139fe00000451ec16ea00"),
 				},
 				{
-					values: []interface{}{958724071, 967981814},
+					values: []any{958724071, 967981814},
 					want:   decodeHex("00043924f7e700000439b23af600"),
 				},
 				{
-					values: []interface{}{290624561, 281368602},
+					values: []any{290624561, 281368602},
 					want:   decodeHex("00041152943100000410c5581a00"),
 				},
 				{
-					values: []interface{}{1628942696, 1544546792},
+					values: []any{1628942696, 1544546792},
 					want:   decodeHex("00046117b1680000045c0fe9e800"),
 				},
 				{
-					values: []interface{}{439094547, 457987688},
+					values: []any{439094547, 457987688},
 					want:   decodeHex("00041a2c0d130000041b4c566800"),
 				},
 				{
-					values: []interface{}{691470817, 838419659},
+					values: []any{691470817, 838419659},
 					want:   decodeHex("0004293701e100000431f944cb00"),
 				},
 				{
-					values: []interface{}{2032465891, 2041723634},
+					values: []any{2032465891, 2041723634},
 					want:   decodeHex("00047924f7e300000479b23af200"),
 				},
 				{
-					values: []interface{}{1724551686, 1929537609},
+					values: []any{1724551686, 1929537609},
 					want:   decodeHex("000466ca92060000047302684900"),
 				},
 				{
-					values: []interface{}{958724071, 967981814},
+					values: []any{958724071, 967981814},
 					want:   decodeHex("00043924f7e700000439b23af600"),
 				},
 				{
-					values: []interface{}{1307654654, 1374426858},
+					values: []any{1307654654, 1374426858},
 					want:   decodeHex("00044df139fe00000451ec16ea00"),
 				},
 				{
-					values: []interface{}{2032465891, 2041723634},
+					values: []any{2032465891, 2041723634},
 					want:   decodeHex("00047924f7e300000479b23af200"),
 				},
 				{
-					values: []interface{}{691470817, 838419659},
+					values: []any{691470817, 838419659},
 					want:   decodeHex("0004293701e100000431f944cb00"),
 				},
 				{
-					values: []interface{}{1724551686, 1929537609},
+					values: []any{1724551686, 1929537609},
 					want:   decodeHex("000466ca92060000047302684900"),
 				},
 				{
-					values: []interface{}{55214822, 972879},
+					values: []any{55214822, 972879},
 					want:   decodeHex("0004034a82e6000004000ed84f00"),
 				},
 				{
-					values: []interface{}{1207341986, 1257554950},
+					values: []any{1207341986, 1257554950},
 					want:   decodeHex("000447f693a20000044af4c40600"),
 				},
 				{
-					values: []interface{}{1207341986, 1257554950},
+					values: []any{1207341986, 1257554950},
 					want:   decodeHex("000447f693a20000044af4c40600"),
 				},
 			},

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -57,7 +57,7 @@ func (gs *GlobalStatus) AddReadError(err *joberror.JobError) {
 }
 
 func (gs *GlobalStatus) PrintResultAsJSON(w io.Writer, schema *typedef.Schema, version string) error {
-	result := map[string]interface{}{
+	result := map[string]any{
 		"result":         gs,
 		"gemini_version": version,
 		"schemaHash":     schema.GetHash(),

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -34,7 +34,7 @@ func TestSerialization(t *testing.T) {
 	st.WriteOps.Store(10)
 	st.ReadOps.Store(5)
 
-	baseDate := time.Date(2020, 02, 01, 0, 0, 0, 0, time.UTC)
+	baseDate := time.Date(2020, 0o2, 0o1, 0, 0, 0, 0, time.UTC)
 	for y := 0; y < 5; y++ {
 		st.AddReadError(&joberror.JobError{
 			Timestamp: baseDate.AddDate(0, 0, y),
@@ -44,7 +44,7 @@ func TestSerialization(t *testing.T) {
 		})
 	}
 
-	baseDate = time.Date(2020, 03, 01, 0, 0, 0, 0, time.UTC)
+	baseDate = time.Date(2020, 0o3, 0o1, 0, 0, 0, 0, time.UTC)
 	for y := 0; y < 5; y++ {
 		st.AddWriteError(&joberror.JobError{
 			Timestamp: baseDate.AddDate(0, 0, y),

--- a/pkg/stmtlogger/filelogger.go
+++ b/pkg/stmtlogger/filelogger.go
@@ -124,7 +124,7 @@ func NewFileLogger(filename string) (StmtToFile, error) {
 	if filename == "" {
 		return &nopFileLogger{}, nil
 	}
-	fd, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	fd, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/store/cqlstore.go
+++ b/pkg/store/cqlstore.go
@@ -93,7 +93,7 @@ func (cs *cqlStore) doMutate(ctx context.Context, stmt *typedef.Stmt, ts time.Ti
 	return nil
 }
 
-func (cs *cqlStore) load(ctx context.Context, stmt *typedef.Stmt) (result []map[string]interface{}, err error) {
+func (cs *cqlStore) load(ctx context.Context, stmt *typedef.Stmt) (result []map[string]any, err error) {
 	query, _ := stmt.Query.ToCql()
 	cs.stmtLogger.LogStmt(stmt)
 	iter := cs.session.Query(query, stmt.Values...).WithContext(ctx).Iter()

--- a/pkg/store/helpers.go
+++ b/pkg/store/helpers.go
@@ -25,7 +25,7 @@ import (
 	"github.com/scylladb/gemini/pkg/typedef"
 )
 
-func pks(t *typedef.Table, rows []map[string]interface{}) []string {
+func pks(t *typedef.Table, rows []map[string]any) []string {
 	var keySet []string
 	for _, row := range rows {
 		keys := make([]string, 0, len(t.PartitionKeys)+len(t.ClusteringKeys))
@@ -36,14 +36,14 @@ func pks(t *typedef.Table, rows []map[string]interface{}) []string {
 	return keySet
 }
 
-func extractRowValues(values []string, columns typedef.Columns, row map[string]interface{}) []string {
+func extractRowValues(values []string, columns typedef.Columns, row map[string]any) []string {
 	for _, pk := range columns {
 		values = append(values, fmt.Sprintf(pk.Name+"=%v", row[pk.Name]))
 	}
 	return values
 }
 
-func lt(mi, mj map[string]interface{}) bool {
+func lt(mi, mj map[string]any) bool {
 	switch mis := mi["pk0"].(type) {
 	case []byte:
 		mjs, _ := mj["pk0"].([]byte)
@@ -84,10 +84,10 @@ func lt(mi, mj map[string]interface{}) bool {
 	}
 }
 
-func loadSet(iter *gocql.Iter) []map[string]interface{} {
-	var rows []map[string]interface{}
+func loadSet(iter *gocql.Iter) []map[string]any {
+	var rows []map[string]any
 	for {
-		row := make(map[string]interface{})
+		row := make(map[string]any)
 		if !iter.MapScan(row) {
 			break
 		}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -42,7 +42,7 @@ import (
 )
 
 type loader interface {
-	load(context.Context, *typedef.Stmt) ([]map[string]interface{}, error)
+	load(context.Context, *typedef.Stmt) ([]map[string]any, error)
 }
 
 type storer interface {
@@ -107,7 +107,7 @@ func (n *noOpStore) mutate(context.Context, *typedef.Stmt) error {
 	return nil
 }
 
-func (n *noOpStore) load(context.Context, *typedef.Stmt) ([]map[string]interface{}, error) {
+func (n *noOpStore) load(context.Context, *typedef.Stmt) ([]map[string]any, error) {
 	return nil, nil
 }
 
@@ -178,7 +178,7 @@ func mutate(ctx context.Context, s storeLoader, stmt *typedef.Stmt) error {
 }
 
 func (ds delegatingStore) Check(ctx context.Context, table *typedef.Table, stmt *typedef.Stmt, detailedDiff bool) error {
-	var testRows, oracleRows []map[string]interface{}
+	var testRows, oracleRows []map[string]any
 	var testErr, oracleErr error
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/pkg/tableopts/options.go
+++ b/pkg/tableopts/options.go
@@ -35,7 +35,7 @@ func (o *SimpleOption) ToCQL() string {
 }
 
 type MapOption struct {
-	val map[string]interface{}
+	val map[string]any
 	key string
 }
 

--- a/pkg/testutils/expected_store.go
+++ b/pkg/testutils/expected_store.go
@@ -93,7 +93,7 @@ func (f *ExpectedStore[T]) UpdateExpected(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Marshal funcStmtTests error:%v", err)
 		}
-		err = os.WriteFile(f.filePath, data, 0644)
+		err = os.WriteFile(f.filePath, data, 0o644)
 		if err != nil {
 			t.Fatalf("write to file %s error:%v", f.filePath, err)
 		}

--- a/pkg/testutils/mock_generator.go
+++ b/pkg/testutils/mock_generator.go
@@ -64,8 +64,8 @@ func (g *MockGenerator) GiveOlds(_ []*typedef.ValueWithToken) {}
 func (g *MockGenerator) ReleaseToken(_ uint64) {
 }
 
-func (g *MockGenerator) createPartitionKeyValues(r *rand.Rand) []interface{} {
-	var values []interface{}
+func (g *MockGenerator) createPartitionKeyValues(r *rand.Rand) []any {
+	var values []any
 	for _, pk := range g.table.PartitionKeys {
 		values = append(values, pk.Type.GenValue(r, g.partitionsConfig)...)
 	}

--- a/pkg/typedef/bag.go
+++ b/pkg/typedef/bag.go
@@ -59,7 +59,7 @@ func (ct *BagType) CQLHolder() string {
 	return "?"
 }
 
-func (ct *BagType) CQLPretty(value interface{}) string {
+func (ct *BagType) CQLPretty(value any) string {
 	if reflect.TypeOf(value).Kind() != reflect.Slice {
 		panic(fmt.Sprintf("set cql pretty, unknown type %v", ct))
 	}
@@ -75,18 +75,18 @@ func (ct *BagType) CQLPretty(value interface{}) string {
 	return fmt.Sprintf(format, strings.Join(out, ","))
 }
 
-func (ct *BagType) GenValue(r *rand.Rand, p *PartitionRangeConfig) []interface{} {
+func (ct *BagType) GenValue(r *rand.Rand, p *PartitionRangeConfig) []any {
 	count := utils.RandInt2(r, 1, maxBagSize+1)
-	out := make([]interface{}, count)
+	out := make([]any, count)
 	for i := 0; i < count; i++ {
 		out[i] = ct.ValueType.GenValue(r, p)[0]
 	}
-	return []interface{}{out}
+	return []any{out}
 }
 
-func (ct *BagType) GenJSONValue(r *rand.Rand, p *PartitionRangeConfig) interface{} {
+func (ct *BagType) GenJSONValue(r *rand.Rand, p *PartitionRangeConfig) any {
 	count := utils.RandInt2(r, 1, maxBagSize+1)
-	out := make([]interface{}, count)
+	out := make([]any, count)
 	for i := 0; i < count; i++ {
 		out[i] = ct.ValueType.GenJSONValue(r, p)
 	}

--- a/pkg/typedef/columns.go
+++ b/pkg/typedef/columns.go
@@ -39,7 +39,7 @@ func (cd *ColumnDef) IsValidForPrimaryKey() bool {
 }
 
 func (cd *ColumnDef) UnmarshalJSON(data []byte) error {
-	dataMap := make(map[string]interface{})
+	dataMap := make(map[string]any)
 	if err := json.Unmarshal(data, &dataMap); err != nil {
 		return err
 	}
@@ -49,7 +49,7 @@ func (cd *ColumnDef) UnmarshalJSON(data []byte) error {
 		if !typeOk {
 			return errors.Wrapf(ErrSchemaValidation, "missing definition of column 'type': [%T]%+[1]v", dataMap)
 		}
-		complexTypeMap, typeMapOk := typeMap.(map[string]interface{})
+		complexTypeMap, typeMapOk := typeMap.(map[string]any)
 		if !typeMapOk {
 			return errors.Wrapf(ErrSchemaValidation, "unknown definition column 'type': [%T]%+[1]v", typeMap)
 		}
@@ -107,7 +107,7 @@ func (c Columns) Remove(column *ColumnDef) Columns {
 	return out
 }
 
-func (c Columns) ToJSONMap(values map[string]interface{}, r *rand.Rand, p *PartitionRangeConfig) map[string]interface{} {
+func (c Columns) ToJSONMap(values map[string]any, r *rand.Rand, p *PartitionRangeConfig) map[string]any {
 	for _, k := range c {
 		values[k.Name] = k.Type.GenJSONValue(r, p)
 	}
@@ -155,9 +155,9 @@ func (c Columns) ValueVariationsNumber(p *PartitionRangeConfig) float64 {
 	return out
 }
 
-func GetMapTypeColumn(data map[string]interface{}) (out *ColumnDef, err error) {
+func GetMapTypeColumn(data map[string]any) (out *ColumnDef, err error) {
 	st := struct {
-		Type map[string]interface{}
+		Type map[string]any
 		Name string
 	}{}
 
@@ -200,9 +200,9 @@ func GetMapTypeColumn(data map[string]interface{}) (out *ColumnDef, err error) {
 	}, err
 }
 
-func GetBagTypeColumn(data map[string]interface{}) (out *ColumnDef, err error) {
+func GetBagTypeColumn(data map[string]any) (out *ColumnDef, err error) {
 	st := struct {
-		Type map[string]interface{}
+		Type map[string]any
 		Name string
 	}{}
 
@@ -231,9 +231,9 @@ func GetBagTypeColumn(data map[string]interface{}) (out *ColumnDef, err error) {
 	}, err
 }
 
-func GetTupleTypeColumn(data map[string]interface{}) (out *ColumnDef, err error) {
+func GetTupleTypeColumn(data map[string]any) (out *ColumnDef, err error) {
 	st := struct {
-		Type map[string]interface{}
+		Type map[string]any
 		Name string
 	}{}
 
@@ -263,9 +263,9 @@ func GetTupleTypeColumn(data map[string]interface{}) (out *ColumnDef, err error)
 	}, nil
 }
 
-func GetUDTTypeColumn(data map[string]interface{}) (out *ColumnDef, err error) {
+func GetUDTTypeColumn(data map[string]any) (out *ColumnDef, err error) {
 	st := struct {
-		Type map[string]interface{}
+		Type map[string]any
 		Name string
 	}{}
 
@@ -303,7 +303,7 @@ func GetUDTTypeColumn(data map[string]interface{}) (out *ColumnDef, err error) {
 	}, nil
 }
 
-func GetSimpleTypeColumn(data map[string]interface{}) (*ColumnDef, error) {
+func GetSimpleTypeColumn(data map[string]any) (*ColumnDef, error) {
 	st := struct {
 		Name string
 		Type SimpleType

--- a/pkg/typedef/interfaces.go
+++ b/pkg/typedef/interfaces.go
@@ -23,9 +23,9 @@ type Type interface {
 	Name() string
 	CQLDef() string
 	CQLHolder() string
-	CQLPretty(interface{}) string
-	GenValue(*rand.Rand, *PartitionRangeConfig) []interface{}
-	GenJSONValue(*rand.Rand, *PartitionRangeConfig) interface{}
+	CQLPretty(any) string
+	GenValue(*rand.Rand, *PartitionRangeConfig) []any
+	GenJSONValue(*rand.Rand, *PartitionRangeConfig) any
 	LenValue() int
 	// ValueVariationsNumber returns number of bytes generated value holds
 	ValueVariationsNumber(*PartitionRangeConfig) float64

--- a/pkg/typedef/simple_type.go
+++ b/pkg/typedef/simple_type.go
@@ -66,7 +66,7 @@ func (st SimpleType) LenValue() int {
 	return 1
 }
 
-func (st SimpleType) CQLPretty(value interface{}) string {
+func (st SimpleType) CQLPretty(value any) string {
 	switch st {
 	case TYPE_ASCII, TYPE_TEXT, TYPE_VARCHAR, TYPE_INET, TYPE_DATE:
 		return fmt.Sprintf("'%s'", value)
@@ -164,7 +164,7 @@ func (st SimpleType) Indexable() bool {
 	return st != TYPE_DURATION
 }
 
-func (st SimpleType) GenJSONValue(r *rand.Rand, p *PartitionRangeConfig) interface{} {
+func (st SimpleType) GenJSONValue(r *rand.Rand, p *PartitionRangeConfig) any {
 	switch st {
 	case TYPE_BLOB:
 		ln := r.Intn(p.MaxBlobLength) + p.MinBlobLength
@@ -175,11 +175,11 @@ func (st SimpleType) GenJSONValue(r *rand.Rand, p *PartitionRangeConfig) interfa
 	return st.genValue(r, p)
 }
 
-func (st SimpleType) GenValue(r *rand.Rand, p *PartitionRangeConfig) []interface{} {
-	return []interface{}{st.genValue(r, p)}
+func (st SimpleType) GenValue(r *rand.Rand, p *PartitionRangeConfig) []any {
+	return []any{st.genValue(r, p)}
 }
 
-func (st SimpleType) genValue(r *rand.Rand, p *PartitionRangeConfig) interface{} {
+func (st SimpleType) genValue(r *rand.Rand, p *PartitionRangeConfig) any {
 	switch st {
 	case TYPE_ASCII, TYPE_TEXT, TYPE_VARCHAR:
 		ln := r.Intn(p.MaxStringLength) + p.MinStringLength

--- a/pkg/typedef/tuple.go
+++ b/pkg/typedef/tuple.go
@@ -55,8 +55,8 @@ func (t *TupleType) CQLHolder() string {
 	return "(" + strings.TrimRight(strings.Repeat("?,", len(t.ValueTypes)), ",") + ")"
 }
 
-func (t *TupleType) CQLPretty(value interface{}) string {
-	values, ok := value.([]interface{})
+func (t *TupleType) CQLPretty(value any) string {
+	values, ok := value.([]any)
 	if !ok {
 		return "()"
 	}
@@ -76,16 +76,16 @@ func (t *TupleType) Indexable() bool {
 	return true
 }
 
-func (t *TupleType) GenJSONValue(r *rand.Rand, p *PartitionRangeConfig) interface{} {
-	out := make([]interface{}, 0, len(t.ValueTypes))
+func (t *TupleType) GenJSONValue(r *rand.Rand, p *PartitionRangeConfig) any {
+	out := make([]any, 0, len(t.ValueTypes))
 	for _, tp := range t.ValueTypes {
 		out = append(out, tp.GenJSONValue(r, p))
 	}
 	return out
 }
 
-func (t *TupleType) GenValue(r *rand.Rand, p *PartitionRangeConfig) []interface{} {
-	out := make([]interface{}, 0, len(t.ValueTypes))
+func (t *TupleType) GenValue(r *rand.Rand, p *PartitionRangeConfig) []any {
+	out := make([]any, 0, len(t.ValueTypes))
 	for _, tp := range t.ValueTypes {
 		out = append(out, tp.GenValue(r, p)...)
 	}

--- a/pkg/typedef/typedef.go
+++ b/pkg/typedef/typedef.go
@@ -158,7 +158,7 @@ func (st StatementType) PossibleAsyncOperation() bool {
 	}
 }
 
-type Values []interface{}
+type Values []any
 
 func (v Values) Copy() Values {
 	values := make(Values, len(v))

--- a/pkg/typedef/types.go
+++ b/pkg/typedef/types.go
@@ -140,7 +140,7 @@ func (mt *MapType) CQLHolder() string {
 	return "?"
 }
 
-func (mt *MapType) CQLPretty(value interface{}) string {
+func (mt *MapType) CQLPretty(value any) string {
 	if reflect.TypeOf(value).Kind() != reflect.Map {
 		panic(fmt.Sprintf("map cql pretty, unknown type %v", mt))
 	}
@@ -155,7 +155,7 @@ func (mt *MapType) CQLPretty(value interface{}) string {
 	return fmt.Sprintf("{%s}", strings.Join(out, ","))
 }
 
-func (mt *MapType) GenJSONValue(r *rand.Rand, p *PartitionRangeConfig) interface{} {
+func (mt *MapType) GenJSONValue(r *rand.Rand, p *PartitionRangeConfig) any {
 	count := r.Intn(9) + 1
 	vals := reflect.MakeMap(reflect.MapOf(reflect.TypeOf(mt.KeyType.GenJSONValue(r, p)), reflect.TypeOf(mt.ValueType.GenJSONValue(r, p))))
 	for i := 0; i < count; i++ {
@@ -164,13 +164,13 @@ func (mt *MapType) GenJSONValue(r *rand.Rand, p *PartitionRangeConfig) interface
 	return vals.Interface()
 }
 
-func (mt *MapType) GenValue(r *rand.Rand, p *PartitionRangeConfig) []interface{} {
+func (mt *MapType) GenValue(r *rand.Rand, p *PartitionRangeConfig) []any {
 	count := utils.RandInt2(r, 1, maxMapSize+1)
 	vals := reflect.MakeMap(reflect.MapOf(reflect.TypeOf(mt.KeyType.GenValue(r, p)[0]), reflect.TypeOf(mt.ValueType.GenValue(r, p)[0])))
 	for i := 0; i < count; i++ {
 		vals.SetMapIndex(reflect.ValueOf(mt.KeyType.GenValue(r, p)[0]), reflect.ValueOf(mt.ValueType.GenValue(r, p)[0]))
 	}
-	return []interface{}{vals.Interface()}
+	return []any{vals.Interface()}
 }
 
 func (mt *MapType) LenValue() int {
@@ -209,22 +209,22 @@ func (ct *CounterType) CQLHolder() string {
 	return "?"
 }
 
-func (ct *CounterType) CQLPretty(value interface{}) string {
+func (ct *CounterType) CQLPretty(value any) string {
 	return fmt.Sprintf("%d", value)
 }
 
-func (ct *CounterType) GenJSONValue(r *rand.Rand, _ *PartitionRangeConfig) interface{} {
+func (ct *CounterType) GenJSONValue(r *rand.Rand, _ *PartitionRangeConfig) any {
 	if utils.UnderTest {
 		return r.Int63()
 	}
 	return atomic.AddInt64(&ct.Value, 1)
 }
 
-func (ct *CounterType) GenValue(r *rand.Rand, _ *PartitionRangeConfig) []interface{} {
+func (ct *CounterType) GenValue(r *rand.Rand, _ *PartitionRangeConfig) []any {
 	if utils.UnderTest {
-		return []interface{}{r.Int63()}
+		return []any{r.Int63()}
 	}
-	return []interface{}{atomic.AddInt64(&ct.Value, 1)}
+	return []any{atomic.AddInt64(&ct.Value, 1)}
 }
 
 func (ct *CounterType) LenValue() int {

--- a/pkg/typedef/types_test.go
+++ b/pkg/typedef/types_test.go
@@ -29,126 +29,126 @@ var prettytests = []struct {
 	typ      Type
 	query    string
 	expected string
-	values   []interface{}
+	values   []any
 }{
 	{
 		typ:      TYPE_ASCII,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{"a"},
+		values:   []any{"a"},
 		expected: "SELECT * FROM tbl WHERE pk0='a'",
 	},
 	{
 		typ:      TYPE_BIGINT,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{big.NewInt(10)},
+		values:   []any{big.NewInt(10)},
 		expected: "SELECT * FROM tbl WHERE pk0=10",
 	},
 	{
 		typ:      TYPE_BLOB,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{"a"},
+		values:   []any{"a"},
 		expected: "SELECT * FROM tbl WHERE pk0=textasblob('a')",
 	},
 	{
 		typ:      TYPE_BOOLEAN,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{true},
+		values:   []any{true},
 		expected: "SELECT * FROM tbl WHERE pk0=true",
 	},
 	{
 		typ:      TYPE_DATE,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{millennium.Format("2006-01-02")},
+		values:   []any{millennium.Format("2006-01-02")},
 		expected: "SELECT * FROM tbl WHERE pk0='1999-12-31'",
 	},
 	{
 		typ:      TYPE_DECIMAL,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{inf.NewDec(1000, 0)},
+		values:   []any{inf.NewDec(1000, 0)},
 		expected: "SELECT * FROM tbl WHERE pk0=1000",
 	},
 	{
 		typ:      TYPE_DOUBLE,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{10.0},
+		values:   []any{10.0},
 		expected: "SELECT * FROM tbl WHERE pk0=10.00",
 	},
 	{
 		typ:      TYPE_DURATION,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{10 * time.Minute},
+		values:   []any{10 * time.Minute},
 		expected: "SELECT * FROM tbl WHERE pk0=10m0s",
 	},
 	{
 		typ:      TYPE_FLOAT,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{10.0},
+		values:   []any{10.0},
 		expected: "SELECT * FROM tbl WHERE pk0=10.00",
 	},
 	{
 		typ:      TYPE_INET,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{net.ParseIP("192.168.0.1")},
+		values:   []any{net.ParseIP("192.168.0.1")},
 		expected: "SELECT * FROM tbl WHERE pk0='192.168.0.1'",
 	},
 	{
 		typ:      TYPE_INT,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{10},
+		values:   []any{10},
 		expected: "SELECT * FROM tbl WHERE pk0=10",
 	},
 	{
 		typ:      TYPE_SMALLINT,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{2},
+		values:   []any{2},
 		expected: "SELECT * FROM tbl WHERE pk0=2",
 	},
 	{
 		typ:      TYPE_TEXT,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{"a"},
+		values:   []any{"a"},
 		expected: "SELECT * FROM tbl WHERE pk0='a'",
 	},
 	{
 		typ:      TYPE_TIME,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{millennium.UnixNano()},
+		values:   []any{millennium.UnixNano()},
 		expected: "SELECT * FROM tbl WHERE pk0='" + millennium.Format("15:04:05.999") + "'",
 	},
 	{
 		typ:      TYPE_TIMESTAMP,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{millennium.UnixMilli()},
+		values:   []any{millennium.UnixMilli()},
 		expected: "SELECT * FROM tbl WHERE pk0='" + millennium.Format("2006-01-02T15:04:05.999-0700") + "'",
 	},
 	{
 		typ:      TYPE_TIMEUUID,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{"63176980-bfde-11d3-bc37-1c4d704231dc"},
+		values:   []any{"63176980-bfde-11d3-bc37-1c4d704231dc"},
 		expected: "SELECT * FROM tbl WHERE pk0=63176980-bfde-11d3-bc37-1c4d704231dc",
 	},
 	{
 		typ:      TYPE_TINYINT,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{1},
+		values:   []any{1},
 		expected: "SELECT * FROM tbl WHERE pk0=1",
 	},
 	{
 		typ:      TYPE_UUID,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{"63176980-bfde-11d3-bc37-1c4d704231dc"},
+		values:   []any{"63176980-bfde-11d3-bc37-1c4d704231dc"},
 		expected: "SELECT * FROM tbl WHERE pk0=63176980-bfde-11d3-bc37-1c4d704231dc",
 	},
 	{
 		typ:      TYPE_VARCHAR,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{"a"},
+		values:   []any{"a"},
 		expected: "SELECT * FROM tbl WHERE pk0='a'",
 	},
 	{
 		typ:      TYPE_VARINT,
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{big.NewInt(1001)},
+		values:   []any{big.NewInt(1001)},
 		expected: "SELECT * FROM tbl WHERE pk0=1001",
 	},
 	{
@@ -158,7 +158,7 @@ var prettytests = []struct {
 			Frozen:      false,
 		},
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{[]string{"a", "b"}},
+		values:   []any{[]string{"a", "b"}},
 		expected: "SELECT * FROM tbl WHERE pk0={'a','b'}",
 	},
 	{
@@ -168,7 +168,7 @@ var prettytests = []struct {
 			Frozen:      false,
 		},
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{[]string{"a", "b"}},
+		values:   []any{[]string{"a", "b"}},
 		expected: "SELECT * FROM tbl WHERE pk0=['a','b']",
 	},
 	{
@@ -178,7 +178,7 @@ var prettytests = []struct {
 			Frozen:    false,
 		},
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{map[string]string{"a": "b"}},
+		values:   []any{map[string]string{"a": "b"}},
 		expected: "SELECT * FROM tbl WHERE pk0={'a':'b'}",
 	},
 	{
@@ -188,7 +188,7 @@ var prettytests = []struct {
 			Frozen:    false,
 		},
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{map[string]string{"a": "b"}},
+		values:   []any{map[string]string{"a": "b"}},
 		expected: "SELECT * FROM tbl WHERE pk0={'a':textasblob('b')}",
 	},
 	{
@@ -197,7 +197,7 @@ var prettytests = []struct {
 			Frozen:     false,
 		},
 		query:    "SELECT * FROM tbl WHERE pk0=?",
-		values:   []interface{}{"a"},
+		values:   []any{"a"},
 		expected: "SELECT * FROM tbl WHERE pk0='a'",
 	},
 	{
@@ -206,7 +206,7 @@ var prettytests = []struct {
 			Frozen:     false,
 		},
 		query:    "SELECT * FROM tbl WHERE pk0={?,?}",
-		values:   []interface{}{"a", "b"},
+		values:   []any{"a", "b"},
 		expected: "SELECT * FROM tbl WHERE pk0={'a','b'}",
 	},
 }

--- a/pkg/typedef/udt.go
+++ b/pkg/typedef/udt.go
@@ -48,8 +48,8 @@ func (t *UDTType) CQLHolder() string {
 	return "?"
 }
 
-func (t *UDTType) CQLPretty(value interface{}) string {
-	s, ok := value.(map[string]interface{})
+func (t *UDTType) CQLPretty(value any) string {
+	s, ok := value.(map[string]any)
 	if !ok {
 		panic(fmt.Sprintf("udt pretty, unknown type %v", t))
 	}
@@ -74,20 +74,20 @@ func (t *UDTType) Indexable() bool {
 	return true
 }
 
-func (t *UDTType) GenJSONValue(r *rand.Rand, p *PartitionRangeConfig) interface{} {
-	vals := make(map[string]interface{})
+func (t *UDTType) GenJSONValue(r *rand.Rand, p *PartitionRangeConfig) any {
+	vals := make(map[string]any)
 	for name, typ := range t.ValueTypes {
 		vals[name] = typ.GenJSONValue(r, p)
 	}
 	return vals
 }
 
-func (t *UDTType) GenValue(r *rand.Rand, p *PartitionRangeConfig) []interface{} {
-	vals := make(map[string]interface{})
+func (t *UDTType) GenValue(r *rand.Rand, p *PartitionRangeConfig) []any {
+	vals := make(map[string]any)
 	for name, typ := range t.ValueTypes {
 		vals[name] = typ.GenValue(r, p)[0]
 	}
-	return []interface{}{vals}
+	return []any{vals}
 }
 
 func (t *UDTType) LenValue() int {


### PR DESCRIPTION
Since we switched to new go versions, we can take advantage in readability that comes with it. This simple change, replaces all `interface{}` with `any`.