### PR TITLE
fix(scylla): failed to start scylla due to fs.aio limit

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -8,7 +8,7 @@ on:
       - .github/workflows/dockerhub-description.yml
 jobs:
   description:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Lint Test and Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name:
         uses: actions/checkout@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,7 +33,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      max-parallel: 4
       matrix:
         gemini-features: ["basic", "normal"]
         gemini-concurrency: [4]

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name:
         uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     needs: [build]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,6 +49,10 @@ jobs:
         id: scylla
         shell: bash
         run: |
+          ulimit -n 65536
+          sudo sysctl -w fs.aio-max-nr=30000000
+          sudo sysctl -w fs.file-max=30000000
+
           chmod +x ./bin/gemini
           make scylla-setup \
             SCYLLA_TEST_VERSION=${{ matrix.test-scylla-version }} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,10 @@ setup: $(GOBIN)/golangci-lint scylla-setup debug-build
 scylla-setup:
 	@docker compose -f docker/docker-compose-$(DOCKER_COMPOSE_TESTING).yml up -d
 
+	until docker logs gemini-oracle 2>&1 | grep "Starting listening for CQL clients" > /dev/null; do sleep 0.2; done
+	until docker logs gemini-test 2>&1 | grep "Starting listening for CQL clients" > /dev/null; do sleep 0.2; done
+
+
 .PHONY: scylla-shutdown
 scylla-shutdown:
 	@docker compose -f docker/docker-compose-$(DOCKER_COMPOSE_TESTING).yml down --volumes


### PR DESCRIPTION
When running multiple ScyllaDB instances on the same machine (especially in docker), it can fail to start due to the `fs.aio-max-nr` kernel setting being too low. This makes our `Integration Tests` unstable and many times tests are being aborted due to Scylla never starting.

## Upgrading to `ubuntu-24.04`

Since Github `ubuntu-latest` will be moving to `24.04` and this fix for some reason does not work on `latest` (didn't investigate why) upgrade to `24.04` is necessary (and it it is proven to work on `24.04`)

## Runs

- https://github.com/scylladb/gemini/actions/runs/12238934057/job/34138199744
- https://github.com/scylladb/gemini/actions/runs/12076017914/job/33676763946