### PR TITLE
Fix/double entries in lists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,8 @@ require (
 	github.com/scylladb/gocqlx/v3 v3.0.2
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
+	github.com/testcontainers/testcontainers-go v0.37.0
+	github.com/testcontainers/testcontainers-go/modules/scylladb v0.37.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20250606033433-dcc06ee1d476
@@ -219,8 +221,6 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/tdakkota/asciicheck v0.4.1 // indirect
-	github.com/testcontainers/testcontainers-go v0.37.0 // indirect
-	github.com/testcontainers/testcontainers-go/modules/scylladb v0.37.0 // indirect
 	github.com/tetafro/godot v1.5.1 // indirect
 	github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67 // indirect
 	github.com/timonwong/loggercheck v0.11.0 // indirect

--- a/pkg/stmtlogger/filelogger.go
+++ b/pkg/stmtlogger/filelogger.go
@@ -72,7 +72,7 @@ type (
 
 func NewFileLogger(filename string, compression Compression) (StmtToFile, error) {
 	if filename == "" {
-		return &nopFileLogger{}, nil
+		return nil, nil
 	}
 
 	fd, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
@@ -228,9 +228,3 @@ func committer(ch <-chan []byte, wg *sync.WaitGroup, writer io.Writer, chMetrics
 		counter++
 	}
 }
-
-type nopFileLogger struct{}
-
-func (n *nopFileLogger) LogStmt(_ *typedef.Stmt, _ mo.Option[time.Time]) error { return nil }
-
-func (n *nopFileLogger) Close() error { return nil }

--- a/pkg/store/cqlstore_test.go
+++ b/pkg/store/cqlstore_test.go
@@ -1,0 +1,19 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/scylladb/gemini/pkg/utils"
+)
+
+func Test_DuplicateValuesWithCompare(t *testing.T) {
+	t.Parallel()
+
+	_, _ = utils.TestContainers(t)
+
+	assert := require.New(t)
+
+	assert.True(true)
+}

--- a/pkg/store/cqlstore_test.go
+++ b/pkg/store/cqlstore_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 ScyllaDB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package store
 
 import (

--- a/pkg/store/cqlstore_test.go
+++ b/pkg/store/cqlstore_test.go
@@ -1,19 +1,108 @@
 package store
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/gocql/gocql"
+	"github.com/samber/mo"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
+	"github.com/scylladb/gemini/pkg/replication"
+	"github.com/scylladb/gemini/pkg/typedef"
 	"github.com/scylladb/gemini/pkg/utils"
 )
 
 func Test_DuplicateValuesWithCompare(t *testing.T) {
 	t.Parallel()
 
-	_, _ = utils.TestContainers(t)
-
 	assert := require.New(t)
+	testSession, oracleSession := utils.TestContainers(t)
 
-	assert.True(true)
+	assert.NoError(testSession.Query(
+		"CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+	).Exec())
+	assert.NoError(testSession.Query(
+		"CREATE TABLE ks1.table_1 (id timeuuid PRIMARY KEY, value list<text>)",
+	).Exec())
+	assert.NoError(oracleSession.Query(
+		"CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+	).Exec())
+	assert.NoError(oracleSession.Query(
+		"CREATE TABLE ks1.table_1 (id timeuuid PRIMARY KEY, value list<text>)",
+	).Exec())
+
+	schema := &typedef.Schema{
+		Keyspace: typedef.Keyspace{Name: "ks1"},
+		Config: typedef.SchemaConfig{
+			ReplicationStrategy:              replication.NewSimpleStrategy(),
+			OracleReplicationStrategy:        replication.NewSimpleStrategy(),
+			AsyncObjectStabilizationAttempts: 10,
+			UseMaterializedViews:             false,
+			AsyncObjectStabilizationDelay:    10 * time.Millisecond,
+		},
+		Tables: []*typedef.Table{{
+			Name: "table_1",
+			Columns: typedef.Columns{
+				{Name: "id", Type: typedef.TypeUuid},
+				{Name: "id", Type: &typedef.BagType{
+					ComplexType: typedef.TypeList,
+					ValueType:   typedef.TypeText,
+					Frozen:      false,
+				}},
+			},
+		}},
+	}
+
+	store := &delegatingStore{
+		workers: newWorkers(2),
+		oracleStore: &cqlStore{
+			session:                 oracleSession,
+			schema:                  schema,
+			logger:                  zap.NewNop(),
+			system:                  "oracle",
+			maxRetriesMutate:        1,
+			maxRetriesMutateSleep:   10 * time.Millisecond,
+			useServerSideTimestamps: false,
+		},
+		testStore: &cqlStore{
+			session:                 testSession,
+			schema:                  schema,
+			logger:                  zap.NewNop(),
+			system:                  "test",
+			maxRetriesMutate:        5,
+			maxRetriesMutateSleep:   1 * time.Millisecond,
+			useServerSideTimestamps: false,
+		},
+		logger: zap.NewNop(),
+	}
+
+	uuid := gocql.TimeUUID()
+
+	insert := typedef.SimpleStmt(
+		fmt.Sprintf("INSERT INTO ks1.table_1(id, value) VALUES(%s, ['%s', '%s'])", uuid, "test1", "test2"),
+		typedef.InsertStatementType,
+	)
+
+	insert2 := typedef.SimpleStmt(
+		fmt.Sprintf("INSERT INTO ks1.table_1(id, value) VALUES(%s, ['%s', '%s', '%s'])", uuid, "test1", "test2", "test3"),
+		typedef.InsertStatementType,
+	)
+	timestamp := mo.Some(time.Now())
+
+	// Try to make it insert a double
+	for range 1000 {
+		go func() {
+			_ = store.testStore.mutate(t.Context(), insert2, timestamp)
+		}()
+	}
+
+	check := typedef.SimpleStmt(
+		fmt.Sprintf("SELECT * FROM ks1.table_1 WHERE id = %s", uuid),
+		typedef.InsertStatementType,
+	)
+	assert.NoError(store.Mutate(t.Context(), insert))
+	assert.NoError(store.Check(t.Context(), schema.Tables[0], check, true))
 }

--- a/pkg/store/mocks_test.go
+++ b/pkg/store/mocks_test.go
@@ -16,7 +16,9 @@ package store
 
 import (
 	"context"
+	"time"
 
+	"github.com/samber/mo"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/scylladb/gemini/pkg/typedef"
@@ -27,7 +29,7 @@ type mockStoreLoader struct {
 	mock.Mock
 }
 
-func (m *mockStoreLoader) mutate(ctx context.Context, stmt *typedef.Stmt) error {
+func (m *mockStoreLoader) mutate(ctx context.Context, stmt *typedef.Stmt, _ mo.Option[time.Time]) error {
 	args := m.Called(ctx, stmt)
 	return args.Error(0)
 }

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -17,13 +17,15 @@ package store
 import (
 	"context"
 	"errors"
-	"github.com/scylladb/gemini/pkg/typedef"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"go.uber.org/zap"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
+
+	"github.com/scylladb/gemini/pkg/typedef"
 )
 
 func TestDelegatingStore_Mutate(t *testing.T) {

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -17,15 +17,13 @@ package store
 import (
 	"context"
 	"errors"
-	"sync"
-	"testing"
-	"time"
-
+	"github.com/scylladb/gemini/pkg/typedef"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
-
-	"github.com/scylladb/gemini/pkg/typedef"
+	"sync"
+	"testing"
+	"time"
 )
 
 func TestDelegatingStore_Mutate(t *testing.T) {

--- a/pkg/store/workers.go
+++ b/pkg/store/workers.go
@@ -82,6 +82,10 @@ func (w *workers) Send(ctx context.Context, cb func(context.Context) (Rows, erro
 }
 
 func (w *workers) Release(ch chan mo.Result[Rows]) {
+	if ch == nil {
+		return
+	}
+
 	select {
 	case <-ch:
 	default:

--- a/pkg/utils/undertest.go
+++ b/pkg/utils/undertest.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gocql/gocql"
 )
@@ -26,7 +27,7 @@ func IsUnderTest() bool {
 	return false
 }
 
-func TestContainers(tb testing.TB) (*gocql.Session, *gocql.Session) {
+func TestContainers(tb testing.TB, _ ...time.Duration) (*gocql.Session, *gocql.Session) {
 	tb.Helper()
 	tb.Fatal("TestContainers is not supported outside of testing build tag")
 	return nil, nil

--- a/pkg/utils/undertest.go
+++ b/pkg/utils/undertest.go
@@ -16,6 +16,18 @@
 
 package utils
 
+import (
+	"testing"
+
+	"github.com/gocql/gocql"
+)
+
 func IsUnderTest() bool {
 	return false
+}
+
+func TestContainers(tb testing.TB) (*gocql.Session, *gocql.Session) {
+	tb.Helper()
+	tb.Fatal("TestContainers is not supported outside of testing build tag")
+	return nil, nil
 }

--- a/pkg/utils/undertest_testing.go
+++ b/pkg/utils/undertest_testing.go
@@ -1,4 +1,4 @@
-// Copyright 2019 ScyllaDB
+// Copyright 2025 ScyllaDB
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,128 @@
 
 package utils
 
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gocql/gocql"
+
+	dockernetwork "github.com/docker/docker/api/types/network"
+	"github.com/testcontainers/testcontainers-go/modules/scylladb"
+	"github.com/testcontainers/testcontainers-go/network"
+)
+
+const ContainerNetworkName = "scylla-gemini"
+
 func IsUnderTest() bool {
 	return true
+}
+
+func TestContainers(tb testing.TB) (*gocql.Session, *gocql.Session) {
+	tb.Helper()
+
+	oracleVersion, exists := os.LookupEnv("GEMINI_SCYLLA_ORACLE")
+	if !exists || oracleVersion == "" {
+		oracleVersion = "6.2"
+	}
+
+	testVersion, exists := os.LookupEnv("GEMINI_SCYLLA_TEST")
+	if !exists || testVersion == "" {
+		testVersion = "2025.1"
+	}
+
+	sharedNetwork, err := network.New(
+		tb.Context(),
+		network.WithDriver("bridge"),
+		network.WithAttachable(),
+		network.WithIPAM(&dockernetwork.IPAM{
+			Driver: "default",
+			Config: []dockernetwork.IPAMConfig{
+				{
+					Subnet:  "192.168.105.0/24",
+					Gateway: "192.168.105.1",
+				},
+			},
+		}),
+	)
+	if err != nil {
+		tb.Fatalf("failed to create shared network: %v", err)
+	}
+
+	tb.Cleanup(func() {
+		_ = sharedNetwork.Remove(tb.Context())
+	})
+
+	oracle, err := scylladb.Run(tb.Context(),
+		"scylladb/scylla:"+oracleVersion,
+		scylladb.WithCustomCommands("--memory=512M", "--smp=1", "--developer-mode=1", "--overprovisioned=1"),
+		scylladb.WithShardAwareness(),
+		network.WithNetwork([]string{ContainerNetworkName}, sharedNetwork),
+	)
+
+	if err != nil {
+		tb.Fatalf("failed to start oracle ScyllaDB container: %v", err)
+	}
+
+	tb.Cleanup(func() {
+		_ = oracle.Terminate(tb.Context())
+	})
+
+	test, err := scylladb.Run(tb.Context(),
+		"scylladb/scylla:"+testVersion,
+		scylladb.WithCustomCommands("--memory=512M", "--smp=1", "--developer-mode=1", "--overprovisioned=1"),
+		scylladb.WithShardAwareness(),
+		network.WithNetwork([]string{ContainerNetworkName}, sharedNetwork),
+	)
+
+	if err != nil {
+		tb.Fatalf("failed to start oracle ScyllaDB container: %v", err)
+	}
+
+	tb.Cleanup(func() {
+		_ = test.Terminate(tb.Context())
+	})
+
+	oracleCluster := gocql.NewCluster(Must(oracle.ContainerIP(tb.Context())))
+	oracleCluster.Timeout = 10 * time.Second
+	oracleCluster.ConnectTimeout = 10 * time.Second
+	oracleCluster.RetryPolicy = &gocql.SimpleRetryPolicy{NumRetries: 0}
+	oracleCluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(gocql.RoundRobinHostPolicy())
+	oracleCluster.Consistency = gocql.Quorum
+	oracleCluster.DefaultTimestamp = false
+	if err = oracleCluster.Validate(); err != nil {
+		tb.Fatalf("failed to validate oracle ScyllaDB cluster: %v", err)
+	}
+
+	testCluster := gocql.NewCluster(Must(test.ContainerIP(tb.Context())))
+	testCluster.Timeout = 10 * time.Second
+	testCluster.ConnectTimeout = 10 * time.Second
+	testCluster.RetryPolicy = &gocql.SimpleRetryPolicy{NumRetries: 0}
+	testCluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(gocql.RoundRobinHostPolicy())
+	testCluster.Consistency = gocql.Quorum
+	testCluster.DefaultTimestamp = false
+	if err = testCluster.Validate(); err != nil {
+		tb.Fatalf("failed to validate test ScyllaDB cluster: %v", err)
+	}
+
+	oracleSession, err := oracleCluster.CreateSession()
+	if err != nil {
+		tb.Fatalf("failed to create oracle ScyllaDB session: %v", err)
+	}
+
+	tb.Cleanup(func() {
+		oracleSession.Close()
+	})
+
+	testSession, err := testCluster.CreateSession()
+	if err != nil {
+		tb.Fatalf("failed to create test ScyllaDB session: %v", err)
+	}
+
+	tb.Cleanup(func() {
+		testSession.Close()
+	})
+
+	return testSession, oracleSession
 }

--- a/pkg/utils/undertest_testing.go
+++ b/pkg/utils/undertest_testing.go
@@ -17,6 +17,8 @@
 package utils
 
 import (
+	"fmt"
+	"math/rand/v2"
 	"os"
 	"testing"
 	"time"
@@ -46,6 +48,8 @@ func TestContainers(tb testing.TB, timeouts ...time.Duration) (*gocql.Session, *
 		testVersion = "2025.1"
 	}
 
+	ipPart := rand.IntN(155) + 100
+
 	sharedNetwork, err := network.New(
 		tb.Context(),
 		network.WithDriver("bridge"),
@@ -54,8 +58,8 @@ func TestContainers(tb testing.TB, timeouts ...time.Duration) (*gocql.Session, *
 			Driver: "default",
 			Config: []dockernetwork.IPAMConfig{
 				{
-					Subnet:  "192.168.105.0/24",
-					Gateway: "192.168.105.1",
+					Subnet:  fmt.Sprintf("192.168.%d.0/24", ipPart),
+					Gateway: fmt.Sprintf("192.168.%d.1", ipPart),
 				},
 			},
 		}),

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -164,3 +164,11 @@ func Sizeof(v any) uint64 {
 		return uint64(unsafe.Sizeof(v))
 	}
 }
+
+func Must[T any](val T, err error) T {
+	if err != nil {
+		panic(fmt.Sprintf("unexpected error: %+v", err))
+	}
+
+	return val
+}


### PR DESCRIPTION
Here is the test suite to replicate the issue #436, it spawns two clusters (test and oracle) and tries to insert at the same time the same query(there are two queries with one value difference, to demonstrate the duplication). Looks like that putting the query to the bounded workers queue and allowing external timestamp mitigates this issue.

Closes #436 