### PR TITLE
fix(json-insert): go time.Duration.String is not compatible with Scylla Duration string

### DIFF
--- a/pkg/generators/statements/insert.go
+++ b/pkg/generators/statements/insert.go
@@ -131,7 +131,7 @@ func convertForJSON(vType typedef.Type, value any) any {
 	case typedef.TypeDate:
 		return value.(time.Time).Format(time.DateOnly)
 	case typedef.TypeDuration:
-		return value.(time.Duration).String()
+		return utils.TimeDurationToScyllaDuration(value.(time.Duration))
 	case typedef.TypeDecimal:
 		return value.(*inf.Dec).String()
 	case typedef.TypeUuid, typedef.TypeTimeuuid:

--- a/pkg/typedef/simple_type.go
+++ b/pkg/typedef/simple_type.go
@@ -137,7 +137,7 @@ func (st SimpleType) GenJSONValue(r utils.Random, p *PartitionRangeConfig) any {
 	case TypeDate:
 		return utils.RandDate(r).Format(time.DateOnly)
 	case TypeDuration:
-		return utils.RandDuration(r).String()
+		return utils.TimeDurationToScyllaDuration(utils.RandDuration(r))
 	case TypeTime:
 		return time.
 			Unix(0, utils.RandTime(r)).

--- a/pkg/utils/time.go
+++ b/pkg/utils/time.go
@@ -1,0 +1,57 @@
+// Copyright 2025 ScyllaDB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"strconv"
+	"time"
+)
+
+type durationUnit struct {
+	name string
+	ns   int64
+}
+
+var units = [10]durationUnit{
+	{"y", 365 * 24 * 60 * 60 * 1_000_000_000},
+	{"mo", 30 * 24 * 60 * 60 * 1_000_000_000},
+	{"w", 7 * 24 * 60 * 60 * 1_000_000_000},
+	{"d", 24 * 60 * 60 * 1_000_000_000},
+	{"h", 60 * 60 * 1_000_000_000},
+	{"m", 60 * 1_000_000_000},
+	{"s", 1_000_000_000},
+	{"ms", 1_000_000},
+	{"us", 1_000},
+	{"ns", 1},
+}
+
+func TimeDurationToScyllaDuration(d time.Duration) string {
+	if d == 0 {
+		return "0ns"
+	}
+
+	result := make([]byte, 0, 64)
+	remaining := d.Nanoseconds()
+
+	for _, unit := range units {
+		if count := remaining / unit.ns; count > 0 {
+			result = strconv.AppendInt(result, count, 10)
+			result = append(result, unit.name...)
+			remaining %= unit.ns
+		}
+	}
+
+	return UnsafeString(result)
+}

--- a/pkg/utils/time_test.go
+++ b/pkg/utils/time_test.go
@@ -1,0 +1,108 @@
+// Copyright 2025 ScyllaDB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/scylladb/gemini/pkg/utils"
+)
+
+func TestTimeDurationToScyllaDuration(t *testing.T) {
+	t.Parallel()
+	assert := require.New(t)
+
+	duration := 10*365*24*time.Hour + // 10 years (approx)
+		2*30*24*time.Hour + // 2 months (approx)
+		1*7*24*time.Hour + // 1 week
+		2*24*time.Hour + // 2 days
+		1*time.Hour + // 1 hour
+		30*time.Minute + // 30 minutes
+		45*time.Second + // 45 seconds
+		500*time.Millisecond + // 500 milliseconds
+		200*time.Microsecond + // 200 microseconds
+		100*time.Nanosecond // 100 nanoseconds
+
+	expected := "10y2mo1w2d1h30m45s500ms200us100ns"
+
+	result := utils.TimeDurationToScyllaDuration(duration)
+
+	assert.Equal(expected, result, "The formatted duration should match the expected string")
+}
+
+func BenchmarkTimeDurationToScyllaDuration(b *testing.B) {
+	b.ReportAllocs()
+	// Test cases with different complexity levels
+	testCases := []struct {
+		name     string
+		duration time.Duration
+	}{
+		{
+			name:     "Simple",
+			duration: 5*time.Second + 100*time.Millisecond,
+		},
+		{
+			name: "Complex", //nolint:usestdlibvars
+			//nolint:lll
+			duration: 10*365*24*time.Hour + 2*30*24*time.Hour + 1*7*24*time.Hour + 2*24*time.Hour + 1*time.Hour + 30*time.Minute + 45*time.Second + 500*time.Millisecond + 200*time.Microsecond + 100*time.Nanosecond,
+		},
+		{
+			name:     "Zero",
+			duration: 0,
+		},
+		{
+			name:     "Nanoseconds",
+			duration: 123 * time.Nanosecond,
+		},
+		{
+			name:     "Mixed",
+			duration: 1*time.Hour + 30*time.Minute + 500*time.Millisecond,
+		},
+	}
+
+	b.ResetTimer()
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				_ = utils.TimeDurationToScyllaDuration(tc.duration)
+			}
+		})
+	}
+}
+
+func BenchmarkTimeDurationToScyllaDuration_AllUnits(b *testing.B) {
+	// Benchmark with a duration that exercises all units
+	duration := 10*365*24*time.Hour + // 10 years
+		2*30*24*time.Hour + // 2 months
+		1*7*24*time.Hour + // 1 week
+		2*24*time.Hour + // 2 days
+		1*time.Hour + // 1 hour
+		30*time.Minute + // 30 minutes
+		45*time.Second + // 45 seconds
+		500*time.Millisecond + // 500 milliseconds
+		200*time.Microsecond + // 200 microseconds
+		100*time.Nanosecond // 100 nanoseconds
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = utils.TimeDurationToScyllaDuration(duration)
+	}
+}


### PR DESCRIPTION
When inserting with JSON, we need to serialize duration to Scylla expected format: 
`10y2mo1w2d1h30m45s500ms200us100ns` (these are all possible values for duration, as per Scylla Docs)

My initial though was `time.Duration.String` is compatible with it, and for the most part it is, but it fails when having more than a day duration. The seconds, milliseconds, etc.. become a decimal, this is where scylla fails to insert as observed in [This CI Run](https://github.com/scylladb/gemini/actions/runs/16492718363/job/46631553965). There might me more special cases needed for JSON inserts in the future.

Go `time.Duration.String` output: `257308h18m40.278603964s`

Regular inserts are not affected since `gocql` driver understands the `time.Duration` type and acts on it accordingly.


