### PR TITLE
fix(stmtlogger): use select json to avoid encoding

### DIFF
--- a/pkg/stmtlogger/__snapshots__/scylla_test.snap
+++ b/pkg/stmtlogger/__snapshots__/scylla_test.snap
@@ -5,6 +5,6 @@ createKeyspace
 ---
 
 [TestBuildQueriesCreation - 2]
-CREATE TABLE IF NOT EXISTS ks1_logs.table1_statements(col1 int,col2 ascii,ddl boolean, ts timestamp, ty text, statement text, values blob, host text, attempt smallint, gemini_attempt smallint, error text, dur duration, PRIMARY KEY ((col1,col2, ty), ddl, ts, attempt, gemini_attempt)) WITH caching={'enabled':'true'} AND compression={'sstable_compression':'ZstdCompressor'} AND tombstone_gc={'mode':'immediate'} AND comment='Table to store logs from Oracle and Test statements';
+CREATE TABLE IF NOT EXISTS ks1_logs.table1_statements(col1 int,col2 ascii,ddl boolean, ts timestamp, ty text, statement text, values text, host text, attempt smallint, gemini_attempt smallint, error text, dur duration, PRIMARY KEY ((col1,col2, ty), ddl, ts, attempt, gemini_attempt)) WITH caching={'enabled':'true'} AND compression={'sstable_compression':'ZstdCompressor'} AND tombstone_gc={'mode':'immediate'} AND comment='Table to store logs from Oracle and Test statements';
 createTable
 ---

--- a/pkg/stmtlogger/scylla.go
+++ b/pkg/stmtlogger/scylla.go
@@ -15,11 +15,11 @@
 package stmtlogger
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -31,6 +31,7 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/pkg/errors"
 	"github.com/samber/mo"
+	"github.com/scylladb/gemini/pkg/utils"
 	"github.com/scylladb/gocqlx/v3/qb"
 	"go.uber.org/zap"
 
@@ -41,11 +42,14 @@ import (
 	"github.com/scylladb/gemini/pkg/workpool"
 )
 
-const additionalColumns = "ddl,ts,ty,statement,values,host,attempt,gemini_attempt,error,dur"
+const (
+	additionalColumns       = "ddl,ts,ty,statement,values,host,attempt,gemini_attempt,error,dur"
+	selectAdditionalColumns = "ddl,ts,statement,values,host,attempt,gemini_attempt,error,dur"
+)
 
 var (
-	additionalColumnsArr   = strings.Split(additionalColumns, ",")
-	additionalColumnsCount = len(additionalColumnsArr)
+	additionalColumnsArr       = strings.Split(additionalColumns, ",")
+	selectAdditionalColumnsArr = strings.Split(selectAdditionalColumns, ",")
 )
 
 var ErrEmptyStatementFileName = errors.New("statement file name cannot be empty")
@@ -234,7 +238,7 @@ func (s *ScyllaLogger) commiter(ctx context.Context, partitionKeysCount int) {
 
 	logStatement := func(item Item) {
 		s.metrics.Dec()
-		values := make([]any, 0, partitionKeysCount+additionalColumnsCount)
+		values := make([]any, 0, partitionKeysCount+len(additionalColumnsArr))
 
 		if item.StatementType.IsSchema() {
 			values = append(values, schemaChangeValues...)
@@ -264,16 +268,16 @@ func (s *ScyllaLogger) commiter(ctx context.Context, partitionKeysCount int) {
 			item.Duration.Duration,
 		)
 
-		if len(values) != partitionKeysCount+additionalColumnsCount {
+		if len(values) != partitionKeysCount+len(additionalColumnsArr) {
 			metrics.ErrorMessages.WithLabelValues(
 				"statement_logger",
 				fmt.Sprintf("invalid number of values for Scylla insert: expected=%d actual=%d, values=%v, statement=%s",
-					partitionKeysCount+additionalColumnsCount, len(values), values, item.StatementType,
+					partitionKeysCount+len(additionalColumnsArr), len(values), values, item.StatementType,
 				),
 			).Inc()
 			s.logger.Error(
 				"invalid number of values for Scylla insert",
-				zap.Int("expected", partitionKeysCount+additionalColumnsCount),
+				zap.Int("expected", partitionKeysCount+len(additionalColumnsArr)),
 				zap.Int("actual", len(values)),
 				zap.Any("values", values),
 				zap.Stringer("statement", item.StatementType),
@@ -312,13 +316,13 @@ func (s *ScyllaLogger) commiter(ctx context.Context, partitionKeysCount int) {
 	}
 }
 
-func prepareValues(values mo.Either[[]any, []byte]) []byte {
+func prepareValues(values mo.Either[[]any, []byte]) string {
 	if values.IsLeft() {
 		data, _ := json.Marshal(values.MustLeft())
-		return data
+		return utils.UnsafeString(data)
 	}
 
-	return values.MustRight()
+	return utils.UnsafeString(values.MustRight())
 }
 
 func buildCreateTableQuery(
@@ -349,7 +353,7 @@ func buildCreateTableQuery(
 		builder.WriteRune(',')
 	}
 
-	builder.WriteString("ddl boolean, ts timestamp, ty text, statement text, values blob, host text, attempt smallint, gemini_attempt smallint, error text, dur duration, ")
+	builder.WriteString("ddl boolean, ts timestamp, ty text, statement text, values text, host text, attempt smallint, gemini_attempt smallint, error text, dur duration, ")
 	builder.WriteString("PRIMARY KEY ((")
 	builder.WriteString(partitions)
 	builder.WriteString(", ty), ddl, ts, attempt, gemini_attempt)) WITH caching={'enabled':'true'} AND compression={'sstable_compression':'ZstdCompressor'}")
@@ -362,43 +366,20 @@ func buildCreateTableQuery(
 	return createKeyspace, createTable
 }
 
-func (s *ScyllaLogger) fetchData(ch chan<- Item, ty Type, statement string, values []any) error {
+func (s *ScyllaLogger) fetchData(ch chan<- []byte, statement string, values []any) error {
 	query := s.session.Query(statement, values...)
 	defer query.Release()
 
 	iter := query.Iter()
 
 	for range iter.NumRows() {
-		m := make(map[string]any, additionalColumnsCount)
+		var b []byte
 
-		if !iter.MapScan(m) {
+		if !iter.Scan(&b) {
 			break
 		}
 
-		v := make([]any, 0)
-		var either mo.Either[[]any, []byte]
-
-		data := m["values"].([]byte)
-
-		if err := json.Unmarshal(data, &v); err != nil {
-			either = mo.Left[[]any, []byte](v)
-		} else {
-			either = mo.Right[[]any, []byte](data)
-		}
-
-		item := Item{
-			Start:         Time{Time: m["ts"].(time.Time)},
-			Error:         mo.Right[error, string](m["error"].(string)),
-			Statement:     m["statement"].(string),
-			Host:          m["host"].(string),
-			Type:          ty,
-			Values:        either,
-			Duration:      Duration{Duration: time.Duration(m["dur"].(gocql.Duration).Nanoseconds)},
-			Attempt:       int(m["attempt"].(int16)),
-			GeminiAttempt: int(m["gemini_attempt"].(int16)),
-		}
-
-		ch <- item
+		ch <- b
 	}
 
 	return iter.Close()
@@ -411,7 +392,8 @@ func (s *ScyllaLogger) buildQuery(jobError joberror.JobError, ty Type) ([]string
 		typedef.UpdateStatementType, typedef.DeleteWholePartitionType,
 		typedef.DeleteSingleRowType, typedef.DeleteSingleColumnType:
 		builder := qb.Select(s.keyspaceAndTable).
-			Columns(additionalColumnsArr...).
+			Json().
+			Columns(selectAdditionalColumnsArr...).
 			OrderBy("ts", qb.ASC)
 
 		values := make([]any, 0, len(s.schemaPartitionKeys))
@@ -441,7 +423,8 @@ func (s *ScyllaLogger) buildQuery(jobError joberror.JobError, ty Type) ([]string
 
 		for i := range iterations {
 			builder := qb.Select(s.keyspaceAndTable).
-				Columns(additionalColumnsArr...).
+				Json().
+				Columns(selectAdditionalColumnsArr...).
 				OrderBy("ts", qb.ASC)
 
 			vals := make([]any, 0, len(s.schemaPartitionKeys))
@@ -475,7 +458,7 @@ func (s *ScyllaLogger) buildQuery(jobError joberror.JobError, ty Type) ([]string
 
 func (s *ScyllaLogger) fetchFailedPartitions(ty Type, errs []joberror.JobError) error {
 	var (
-		file   io.Writer
+		file   *bufio.Writer
 		closer func() error
 		err    error
 	)
@@ -494,32 +477,23 @@ func (s *ScyllaLogger) fetchFailedPartitions(ty Type, errs []joberror.JobError) 
 
 		file, closer, err = s.openStatementFile(s.testStatementsFile)
 	default:
-		s.logger.DPanic("unsupported type to fetch from statement logs", zap.String("type", string(ty)))
+		s.logger.Panic("unsupported type to fetch from statement logs", zap.String("type", string(ty)))
 	}
 
 	if err != nil {
-		if closer != nil {
-			if err = closer(); err != nil {
-				s.logger.Error("failed to close oracle statements file", zap.Error(err))
-			}
-		}
-
-		s.logger.Error("failed to open oracle statements file", zap.Error(err))
-
+		s.logger.Error("failed to open statements file", zap.String("type", string(ty)), zap.Error(err))
 		return err
 	}
 
 	defer func() {
 		if err = closer(); err != nil {
-			s.logger.Error("failed to close oracle statements file", zap.Error(err))
+			s.logger.Error("failed to close oracle statements file", zap.String("type", string(ty)), zap.Error(err))
 		}
 	}()
 
-	encoder := json.NewEncoder(file)
-	encoder.SetEscapeHTML(false)
-
 	builder := qb.Select(s.keyspaceAndTable).
-		Columns(additionalColumnsArr...).
+		Json().
+		Columns(selectAdditionalColumnsArr...).
 		OrderBy("ts", qb.ASC)
 
 	for _, pk := range s.schemaPartitionKeys {
@@ -530,7 +504,7 @@ func (s *ScyllaLogger) fetchFailedPartitions(ty Type, errs []joberror.JobError) 
 		Where(qb.EqLit("ddl", "true")).
 		ToCql()
 
-	ch := make(chan Item, 1000)
+	ch := make(chan []byte, 1000)
 	wg := &sync.WaitGroup{}
 
 	wg.Add(1)
@@ -540,7 +514,7 @@ func (s *ScyllaLogger) fetchFailedPartitions(ty Type, errs []joberror.JobError) 
 		schemaChangeValues = append(schemaChangeValues, s.schemaChangeValues.Values.ToCQLValues(s.schemaPartitionKeys)...)
 		schemaChangeValues = append(schemaChangeValues, string(ty))
 
-		if fetchErr := s.fetchData(ch, ty, ddlStatementsQuery, schemaChangeValues); fetchErr != nil {
+		if fetchErr := s.fetchData(ch, ddlStatementsQuery, schemaChangeValues); fetchErr != nil {
 			metrics.ErrorMessages.WithLabelValues("statement_logger_fetch_ddl", fetchErr.Error()).Inc()
 			s.logger.Error("failed to fetch schema change data", zap.Error(fetchErr))
 		}
@@ -557,7 +531,7 @@ func (s *ScyllaLogger) fetchFailedPartitions(ty Type, errs []joberror.JobError) 
 			wg.Add(1)
 			go func(values []any) {
 				defer wg.Done()
-				if fetchErr := s.fetchData(ch, ty, query, values); fetchErr != nil {
+				if fetchErr := s.fetchData(ch, query, values); fetchErr != nil {
 					metrics.ErrorMessages.WithLabelValues("statement_logger_query",
 						fmt.Sprintf(
 							"failed to fetch data for job error %s: error=%v partition-keys=%v", jobError.Error(), fetchErr,
@@ -578,23 +552,51 @@ func (s *ScyllaLogger) fetchFailedPartitions(ty Type, errs []joberror.JobError) 
 	}()
 
 	for item := range ch {
-		if encodeErr := encoder.Encode(item); encodeErr != nil {
-			s.logger.Error("failed to encode oracle statement", zap.Error(encodeErr))
+		if _, err = file.Write(item); err != nil {
+			s.logger.Error("failed to write statement",
+				zap.String("type", string(ty)),
+				zap.String("statement", string(item)),
+				zap.Error(err),
+			)
+
+			continue
 		}
+
+		// Since this is a new line, we can ignore the error
+		// if we fail to write a new line, it will be caught by the next write
+		// and will have two rows on the same line
+		_, _ = file.WriteRune('\n')
 	}
 
 	return nil
 }
 
-func (s *ScyllaLogger) openStatementFile(name string) (io.Writer, func() error, error) {
+func (s *ScyllaLogger) openStatementFile(name string) (*bufio.Writer, func() error, error) {
 	file, err := os.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644|fs.ModeExclusive)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to open test statements file '%q'", name)
 	}
 
-	return file, func() error {
-		_ = file.Sync()
-		return file.Close()
+	buffered := bufio.NewWriterSize(file, 32*1024)
+
+	return buffered, func() error {
+		defer func() {
+			if err = file.Close(); err != nil {
+				s.logger.Error("failed to close statements file", zap.String("file", name), zap.Error(err))
+			}
+		}()
+
+		if err = buffered.Flush(); err != nil {
+			return err
+		}
+
+		if err = file.Sync(); err != nil {
+			s.logger.Error("failed to fsync statements file", zap.String("file", name), zap.Error(err))
+
+			return err
+		}
+
+		return nil
 	}, nil
 }
 

--- a/pkg/stmtlogger/scylla_test.go
+++ b/pkg/stmtlogger/scylla_test.go
@@ -15,6 +15,7 @@
 package stmtlogger
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"slices"
@@ -117,82 +118,124 @@ func errorStatement(ty Type) (Item, joberror.JobError) {
 
 func TestScyllaLogger(t *testing.T) {
 	t.Parallel()
-
+	dir := t.TempDir()
+	oracleFile := dir + "/oracle_statements.json"
+	testFile := dir + "/test_statements.json"
 	item := CompressionTests[0]
 
-	t.Run("Compression_"+item.Compression.String(), func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		oracleFile := dir + "/oracle_statements.json"
-		testFile := dir + "/test_statements.json"
+	assert := require.New(t)
+	scyllaContainer := testutils.SingleScylla(t)
 
-		assert := require.New(t)
-		scyllaContainer := testutils.SingleScylla(t)
+	jobList := joberror.NewErrorList(1)
+	pool := workpool.New(1)
+	t.Cleanup(func() {
+		_ = pool.Close()
+	})
+	chMetrics := metrics.NewChannelMetrics("test", "test")
+	partitionKeys := []typedef.ColumnDef{
+		{Name: "col1", Type: typedef.TypeInt},
+		{Name: "col2", Type: typedef.TypeText},
+	}
 
-		jobList := joberror.NewErrorList(1)
-		pool := workpool.New(1)
-		t.Cleanup(func() {
-			_ = pool.Close()
-		})
-		chMetrics := metrics.NewChannelMetrics("test", "test")
-		partitionKeys := []typedef.ColumnDef{
-			{Name: "col1", Type: typedef.TypeInt},
-			{Name: "col2", Type: typedef.TypeText},
+	ch := make(chan Item, 10)
+	zapLogger := testutils.Must(zap.NewDevelopment())
+
+	logger, err := NewScyllaLoggerWithSession(
+		"ks1",
+		"table1",
+		typedef.PartitionKeys{Values: typedef.NewValuesFromMap(map[string][]any{"col1": {5}, "col2": {"test_ddl"}})},
+		scyllaContainer.Test,
+		partitionKeys,
+		replication.NewNetworkTopologyStrategy(),
+		ch,
+		oracleFile, testFile, item.Compression, jobList,
+		pool, zapLogger, chMetrics,
+	)
+	assert.NoError(err)
+	assert.NotNil(logger)
+
+	itemTest, testJobErr := errorStatement(TypeTest)
+	itemOracle, _ := errorStatement(TypeOracle)
+
+	ch <- ddlStatement(TypeTest)
+	ch <- ddlStatement(TypeOracle)
+	ch <- successStatement(TypeTest)
+	ch <- itemTest
+	ch <- successStatement(TypeOracle)
+	ch <- itemOracle
+
+	jobList.AddError(testJobErr)
+	time.Sleep(2 * time.Second)
+	close(ch)
+	assert.NoError(logger.Close())
+
+	var count int
+	assert.NoError(scyllaContainer.Test.Query(
+		fmt.Sprintf("SELECT COUNT(*) FROM %s.%s",
+			GetScyllaStatementLogsKeyspace("ks1"),
+			GetScyllaStatementLogsTable("table1")),
+	).Scan(&count))
+	assert.Equal(6, count)
+
+	oracleData := item.ReadData(t, testutils.Must(os.Open(oracleFile)))
+	testData := item.ReadData(t, testutils.Must(os.Open(testFile)))
+
+	oracleStatements := strings.SplitSeq(strings.TrimRight(oracleData, "\n"), "\n")
+	testStatements := strings.SplitSeq(strings.TrimRight(testData, "\n"), "\n")
+
+	sortedOracle := slices.SortedStableFunc(oracleStatements, strings.Compare)
+	sortedTest := slices.SortedStableFunc(testStatements, strings.Compare)
+
+	assert.Len(sortedOracle, 2)
+	assert.Len(sortedTest, 2)
+
+	expectItem := func(data string, i Item) {
+		m := make(map[string]any, 10)
+		assert.NoError(json.Unmarshal([]byte(data), &m))
+
+		// Validate error field
+		if i.Error.IsLeft() && i.Error.MustLeft() != nil {
+			assert.Equal(i.Error.MustLeft().Error(), m["error"])
+		} else if i.Error.IsRight() {
+			assert.Equal(i.Error.MustRight(), m["error"])
+		} else {
+			assert.Nil(m["error"])
 		}
 
-		ch := make(chan Item, 10)
-		zapLogger := testutils.Must(zap.NewDevelopment())
+		assert.NotEmpty(m["ts"].(string))
+		assert.Equal(i.Statement, m["statement"])
+		assert.Equal(i.Host, m["host"])
+		assert.Equal(i.Duration.Duration.String(), m["dur"])
+		assert.Equal(float64(i.Attempt), m["attempt"])
 
-		logger, err := NewScyllaLoggerWithSession(
-			"ks1",
-			"table1",
-			typedef.PartitionKeys{Values: typedef.NewValuesFromMap(map[string][]any{"col1": {5}, "col2": {"test_ddl"}})},
-			scyllaContainer.Test,
-			partitionKeys,
-			replication.NewNetworkTopologyStrategy(),
-			ch,
-			oracleFile, testFile, item.Compression, jobList,
-			pool, zapLogger, chMetrics,
-		)
-		assert.NoError(err)
-		assert.NotNil(logger)
+		if i.Values.IsLeft() {
+			values := i.Values.MustLeft()
+			if values != nil {
+				jsonValuesStr := m["values"].(string)
+				// Unescape the JSON string and parse it
+				var parsedValues []any
+				assert.NoError(json.Unmarshal([]byte(jsonValuesStr), &parsedValues), "Failed to unmarshal JSON values")
+				assert.Equal(len(values), len(parsedValues))
+				for idx, val := range values {
+					switch v := val.(type) {
+					case int:
+						assert.Equal(float64(v), parsedValues[idx])
+					case string:
+						assert.Equal(v, parsedValues[idx])
+					default:
+						assert.Equal(val, parsedValues[idx])
+					}
+				}
+			} else {
+				assert.Nil(m["values"])
+			}
+		} else {
+			assert.Equal(string(i.Values.MustRight()), m["values"])
+		}
+	}
 
-		itemTest, testJobErr := errorStatement(TypeTest)
-		itemOracle, _ := errorStatement(TypeOracle)
-
-		ch <- ddlStatement(TypeTest)
-		ch <- ddlStatement(TypeOracle)
-		ch <- successStatement(TypeTest)
-		ch <- itemTest
-		ch <- successStatement(TypeOracle)
-		ch <- itemOracle
-
-		jobList.AddError(testJobErr)
-		time.Sleep(2 * time.Second)
-		close(ch)
-		assert.NoError(logger.Close())
-
-		var count int
-		assert.NoError(scyllaContainer.Test.Query(
-			fmt.Sprintf("SELECT COUNT(*) FROM %s.%s",
-				GetScyllaStatementLogsKeyspace("ks1"),
-				GetScyllaStatementLogsTable("table1")),
-		).Scan(&count))
-		assert.Equal(6, count)
-
-		oracleData := item.ReadData(t, testutils.Must(os.Open(oracleFile)))
-		testData := item.ReadData(t, testutils.Must(os.Open(testFile)))
-
-		oracleStatements := strings.SplitSeq(strings.TrimRight(oracleData, "\n"), "\n")
-		testStatements := strings.SplitSeq(strings.TrimRight(testData, "\n"), "\n")
-
-		sortedOracle := slices.SortedStableFunc(oracleStatements, strings.Compare)
-		sortedTest := slices.SortedStableFunc(testStatements, strings.Compare)
-
-		assert.Equal(sortedOracle, sortedTest)
-		assert.Len(sortedOracle, 2)
-		assert.Len(sortedTest, 2)
-	})
+	expectItem(sortedOracle[0], itemOracle)
+	expectItem(sortedTest[0], itemTest)
 }
 
 func ddlStatement(ty Type) Item {


### PR DESCRIPTION
The `values` inside json statement file were empty (not only values, but other complex types inside `stmtlogger.Item`), due to some encoding error in go or due to some hand cranked json marshaling and unmarshaling. But @soyacz reminded me of `SELECT JSON` feature in scylla which eliminates a lot of code inside `stmtlogger`, and makes it faster when fetching as everything is offloaded to ScyllaDB.  

Closes #519 