### PR TITLE
[FIX] - metrics - `err.Error` for metrics causes panic when non valid UTF-8 char exists

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -48,15 +48,12 @@ func (gs *GlobalStatus) AddWriteError(err joberror.JobError) {
 	gs.WriteErrors.Add(1)
 	metrics.ExecutionErrors.WithLabelValues("write").Add(1)
 	gs.Errors.AddError(err)
-
-	metrics.ErrorMessages.WithLabelValues("write", err.Error()).Inc()
 }
 
 func (gs *GlobalStatus) AddReadError(err joberror.JobError) {
 	gs.ReadErrors.Add(1)
 	metrics.ExecutionErrors.WithLabelValues("read").Inc()
 	gs.Errors.AddError(err)
-	metrics.ErrorMessages.WithLabelValues("read", err.Error()).Inc()
 }
 
 func (gs *GlobalStatus) PrintResultAsJSON(w io.Writer, schema *typedef.Schema, version string, info map[string]any) error {


### PR DESCRIPTION
When error is formatted using `err.Error()` for prometheus error messages (the way to display errors inside prometheus in realtime) some characters could be not UTF-8 valid since Scylla can have Blob type for pk and ck. Just removing this removes this panic and validation error continues to propagate with success

Closes #525