### PR TITLE
feature(go): use go1.25 everywhere

### DIFF
--- a/.github/instructions.md
+++ b/.github/instructions.md
@@ -8,7 +8,7 @@ a system under test (SUT) and a test oracle.
 ## Project Structure
 
 ## Language & Framework
-- **Language**: Go 1.24
+- **Language**: Go 1.25
 - **Architecture**: CLI application with modular package structure
 - **Database**: Scylla/Cassandra using CQL protocol
 - **Testing**: Randomized testing with statistical distributions

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
       - name: Set up gotestfmt
         uses: GoTestTools/gotestfmt-action@v2
@@ -40,3 +40,5 @@ jobs:
           make test
       - uses: golangci/golangci-lint-action@v8
         name: Linting
+        with:
+          install-mode: goinstall

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - name: Build
         run: make build
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       # Needed for ARM64 Docker builds
       - name: Set up QEMU

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 version: "2"
 run:
   concurrency: 16
-  go: "1.24"
+  go: "1.25"
   modules-download-mode: mod
   issues-exit-code: 1
   tests: true
@@ -70,7 +70,7 @@ linters:
       exclude-forbidden: true
       toolchain-forbidden: true
       go-debug-forbidden: true
-      go-version-pattern: '1\.24(\.\d+)?'
+      go-version-pattern: '1\.25(\.\d+)?'
       replace-allow-list:
         - github.com/gocql/gocql
     forbidigo:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-bookworm AS build
+FROM golang:1.25-bookworm AS build
 
 ENV GO111MODULE=on
 ENV GOAMD64=v3
@@ -22,7 +22,7 @@ FROM debian:12-slim AS base-production
 WORKDIR /
 
 ENV DEBIAN_FRONTEND="noninteractive"
-ENV GODEBUG="default=go1.24,netdns=go,gctrace=0,cgocheck=0,disablethp=0,panicnil=0,http2client=1,http2server=1,asynctimerchan=0,madvdontneed=1"
+ENV GODEBUG="default=go1.25,netdns=go,gctrace=0,cgocheck=0,disablethp=0,panicnil=0,http2client=1,http2server=1,asynctimerchan=0,madvdontneed=1"
 ENV PATH="/usr/local/bin:${PATH}"
 
 RUN apt-get update && apt-get upgrade -y \
@@ -49,7 +49,7 @@ RUN gemini --version
 
 FROM build AS debug
 
-ENV GODEBUG="default=go1.24,gctrace=1,cgocheck=1,disablethp=0,panicnil=0,http2client=1,http2server=1,asynctimerchan=0,madvdontneed=0"
+ENV GODEBUG="default=go1.25,gctrace=1,cgocheck=1,disablethp=0,panicnil=0,http2client=1,http2server=1,asynctimerchan=0,madvdontneed=0"
 ENV PATH="/gemini/bin:${PATH}"
 
 RUN apt-get install -y gdb gcc iputils-ping mlocate vim \

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ integration-test:
 	@mkdir -p $(PWD)/results
 	@touch $(PWD)/results/gemini_seed
 	@echo $(GEMINI_SEED) > $(PWD)/results/gemini_seed
-	GODEBUG="default=go1.24,cgocheck=1,disablethp=0,panicnil=0,http2client=1,http2server=1,asynctimerchan=0,madvdontneed=0" GOGC="95" $(GEMINI_BINARY) \
+	GODEBUG="default=go1.25,cgocheck=1,disablethp=0,panicnil=0,http2client=1,http2server=1,asynctimerchan=0,madvdontneed=0" GOGC="95" $(GEMINI_BINARY) \
 		--test-cluster="$(call get_scylla_ip,gemini-test)" \
 		--oracle-cluster="$(call get_scylla_ip,gemini-oracle)" \
 		--replication-strategy="{'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}" \
@@ -206,7 +206,7 @@ integration-cluster-test:
 	@mkdir -p $(PWD)/results
 	@touch $(PWD)/results/gemini_seed
 	@echo $(GEMINI_SEED) > $(PWD)/results/gemini_seed
-	GODEBUG="default=go1.24,cgocheck=1,disablethp=0,panicnil=0,http2client=1,http2server=1,asynctimerchan=0,madvdontneed=0" GOGC="95" \
+	GODEBUG="default=go1.25,cgocheck=1,disablethp=0,panicnil=0,http2client=1,http2server=1,asynctimerchan=0,madvdontneed=0" GOGC="95" \
 	$(GEMINI_BINARY) \
 		--test-cluster="$(call get_scylla_ip,gemini-test-1),$(call get_scylla_ip,gemini-test-2),$(call get_scylla_ip,gemini-test-3)" \
 		--oracle-cluster="$(call get_scylla_ip,gemini-oracle)" \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/scylladb/gemini
 
-go 1.24.0
+go 1.25.0
 
 replace github.com/gocql/gocql => github.com/scylladb/gocql v1.15.3
 

--- a/pkg/joberror/joberror_test.go
+++ b/pkg/joberror/joberror_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/scylladb/gemini/pkg/typedef"
@@ -62,7 +61,7 @@ func TestJobError_ErrorWithEmptyFields(t *testing.T) {
 	}
 
 	actual := jobErr.Error()
-	assert.NotEmpty(t, actual)
+	require.NotEmpty(t, actual)
 }
 
 func TestNewErrorList(t *testing.T) {

--- a/pkg/services/workload_test.go
+++ b/pkg/services/workload_test.go
@@ -261,13 +261,12 @@ func TestWorkload(t *testing.T) {
 
 func TestWorkloadWithoutOracle(t *testing.T) {
 	t.Parallel()
-	logger := getLogger(t)
 	scyllaContainer := testutils.SingleScylla(t)
 
 	for _, test := range dataset {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-
+			logger := getLogger(t)
 			assert := require.New(t)
 			storeConfig := getStoreConfig(t, scyllaContainer.TestHosts, scyllaContainer.OracleHosts)
 			schema := getSchema(t)


### PR DESCRIPTION
During the upgrade to Go 1.25, it showed that we have a `data race` in `partitions` still, even with all fancy features and `data race` inside `test containers` for `random number generation`