### PR TITLE
fix(stmtlogger): map with array of bytes fails to serialize to json

### DIFF
--- a/pkg/joberror/joberror.go
+++ b/pkg/joberror/joberror.go
@@ -16,6 +16,7 @@ package joberror
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -78,6 +79,13 @@ func (j *JobError) Hash() [32]byte {
 
 	j.hash = bytes
 	return bytes
+}
+
+// HashHex returns the hex-encoded string form of the 32-byte hash.
+// Useful for using the hash as a JSON map key or log identifier.
+func (j *JobError) HashHex() string {
+	sum := j.Hash()
+	return hex.EncodeToString(sum[:])
 }
 
 type ErrorList struct {

--- a/pkg/stmtlogger/scylla/cql_json_regression_test.go
+++ b/pkg/stmtlogger/scylla/cql_json_regression_test.go
@@ -1,0 +1,82 @@
+// Copyright 2025 ScyllaDB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scylla
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestEncodeRowToJSONShape ensures that our manual JSON encoding of fragments
+// keeps critical types in a string form compatible with Scylla's SELECT JSON
+// expectations (e.g., timestamps and blobs are stringified).
+func TestEncodeRowToJSONShape(t *testing.T) {
+	t.Parallel()
+
+	when := time.Unix(1732550400, 123456789) // 2024-11-25T00:00:00.123456789Z
+	blob := []byte{0x01, 0x02, 0xFF, 0x00}
+
+	row := map[string]any{
+		"text":  "hello",
+		"num":   int32(42),
+		"ts":    when,
+		"bytes": blob,
+	}
+
+	raw, err := encodeRowToJSON(row)
+	if err != nil {
+		t.Fatalf("encodeRowToJSON failed: %v", err)
+	}
+
+	// Unmarshal to a generic map to assert JSON types
+	var out map[string]any
+	if err = json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unexpected JSON output: %v; data=%s", err, string(raw))
+	}
+
+	// text should be a JSON string
+	if _, ok := out["text"].(string); !ok {
+		t.Fatalf("text not a string: %#v", out["text"])
+	}
+
+	// num should be a JSON number (decoded by Go as float64)
+	if _, ok := out["num"].(float64); !ok {
+		t.Fatalf("num not a number: %#v", out["num"])
+	}
+
+	// ts should be a JSON string in RFC3339 format
+	tsStr, ok := out["ts"].(string)
+	if !ok {
+		t.Fatalf("ts not a string: %#v", out["ts"])
+	}
+	if _, err = time.Parse(time.RFC3339Nano, tsStr); err != nil {
+		t.Fatalf("ts not RFC3339Nano parseable: %q err=%v", tsStr, err)
+	}
+
+	// bytes should be a base64 JSON string
+	b64, ok := out["bytes"].(string)
+	if !ok {
+		t.Fatalf("bytes not a string: %#v", out["bytes"])
+	}
+	dec, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		t.Fatalf("bytes not base64 string: %q err=%v", b64, err)
+	}
+	if string(dec) != string(blob) {
+		t.Fatalf("bytes mismatch after base64 round-trip: got=%v want=%v", dec, blob)
+	}
+}

--- a/pkg/stmtlogger/scylla/cql_map_json_test.go
+++ b/pkg/stmtlogger/scylla/cql_map_json_test.go
@@ -1,0 +1,57 @@
+// Copyright 2025 ScyllaDB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scylla
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+)
+
+// Ensure that cqlDataMap marshals with string keys (hex-encoded) and copies
+// entries into a map[string]cqlData so it can be JSON-encoded easily.
+func TestCQLDataMap_MarshalJSON_Keys(t *testing.T) {
+	t.Parallel()
+
+	var k1, k2 [32]byte
+	k1[0] = 0x01
+	k2[0] = 0xAB
+
+	m := cqlDataMap{
+		k1: {},
+		k2: {},
+	}
+
+	bs, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var out map[string]json.RawMessage
+	if err = json.Unmarshal(bs, &out); err != nil {
+		t.Fatalf("Unmarshal failed: %v; data=%s", err, string(bs))
+	}
+
+	if len(out) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(out))
+	}
+
+	if _, ok := out[hex.EncodeToString(k1[:])]; !ok {
+		t.Fatalf("missing key for k1")
+	}
+	if _, ok := out[hex.EncodeToString(k2[:])]; !ok {
+		t.Fatalf("missing key for k2")
+	}
+}

--- a/pkg/stmtlogger/scylla/scylla_integration_test.go
+++ b/pkg/stmtlogger/scylla/scylla_integration_test.go
@@ -537,7 +537,7 @@ func TestCQLStatements_FetchMultiPartition_Integration(t *testing.T) {
 
 	tests := []struct {
 		jobError  *joberror.JobError
-		checkFunc func(*testing.T, map[[32]byte]cqlData)
+		checkFunc func(*testing.T, cqlDataMap)
 		name      string
 		ty        stmtlogger.Type
 		expectErr bool
@@ -555,7 +555,7 @@ func TestCQLStatements_FetchMultiPartition_Integration(t *testing.T) {
 				}),
 			},
 			expectErr: false,
-			checkFunc: func(t *testing.T, result map[[32]byte]cqlData) {
+			checkFunc: func(t *testing.T, result cqlDataMap) {
 				t.Helper()
 
 				// Result may be empty if statement logs don't match exactly
@@ -576,7 +576,7 @@ func TestCQLStatements_FetchMultiPartition_Integration(t *testing.T) {
 				}),
 			},
 			expectErr: false,
-			checkFunc: func(t *testing.T, result map[[32]byte]cqlData) {
+			checkFunc: func(t *testing.T, result cqlDataMap) {
 				t.Helper()
 				assert.NotNil(t, result)
 			},
@@ -594,7 +594,7 @@ func TestCQLStatements_FetchMultiPartition_Integration(t *testing.T) {
 				}),
 			},
 			expectErr: false,
-			checkFunc: func(t *testing.T, result map[[32]byte]cqlData) {
+			checkFunc: func(t *testing.T, result cqlDataMap) {
 				t.Helper()
 				assert.NotNil(t, result)
 			},
@@ -612,7 +612,7 @@ func TestCQLStatements_FetchMultiPartition_Integration(t *testing.T) {
 				}),
 			},
 			expectErr: true,
-			checkFunc: func(_ *testing.T, _ map[[32]byte]cqlData) {
+			checkFunc: func(_ *testing.T, _ cqlDataMap) {
 				// Should return error for unsupported statement types
 			},
 		},
@@ -629,7 +629,7 @@ func TestCQLStatements_FetchMultiPartition_Integration(t *testing.T) {
 				}),
 			},
 			expectErr: true,
-			checkFunc: func(_ *testing.T, _ map[[32]byte]cqlData) {
+			checkFunc: func(_ *testing.T, _ cqlDataMap) {
 				// Should return error for unsupported statement types
 			},
 		},
@@ -812,7 +812,7 @@ func TestLogger_StatementFlusher_Integration(t *testing.T) {
 	// Send data
 	ch <- statementChData{
 		ty: stmtlogger.TypeOracle,
-		Data: map[[32]byte]cqlData{
+		Data: cqlDataMap{
 			{1}: {
 				partitionKeys: map[string][]any{
 					"pk0": {"test"},

--- a/pkg/stmtlogger/scylla/scylla_regression_test.go
+++ b/pkg/stmtlogger/scylla/scylla_regression_test.go
@@ -1,0 +1,191 @@
+// Copyright 2025 ScyllaDB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//nolint:govet
+package scylla
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap/zaptest"
+
+	"github.com/scylladb/gemini/pkg/joberror"
+	"github.com/scylladb/gemini/pkg/stmtlogger"
+	"github.com/scylladb/gemini/pkg/typedef"
+)
+
+//nolint:gocyclo
+func TestStatementFlusher_JSONMarshalRegression(t *testing.T) {
+	t.Parallel()
+
+	// Prepare temp files
+	dir := t.TempDir()
+	oraclePath := filepath.Join(dir, "oracle_statements.jsonl")
+	testPath := filepath.Join(dir, "test_statements.jsonl")
+
+	// Minimal logger instance sufficient for statementFlusher
+	s := &Logger{logger: zaptest.NewLogger(t)}
+
+	// Channel for flusher
+	ch := make(chan statementChData, 2)
+
+	// Start the flusher
+	go s.statementFlusher(ch, oraclePath, testPath)
+
+	// Create a sample JobError and associated data
+	jobErr := &joberror.JobError{
+		Timestamp: time.Now(),
+		Query:     "SELECT * FROM ks.tbl WHERE pk0 = ? AND pk1 = ?",
+		Message:   "synthetic error for test",
+		StmtType:  typedef.SelectStatementType,
+		PartitionKeys: typedef.NewValuesFromMap(map[string][]any{
+			"pk0": {"abc"},
+			"pk1": {int32(7)},
+		}),
+	}
+
+	// Data map uses [32]byte keys internally – this is the crux of the
+	// regression: such maps must never be sent to JSON encoder via logs.
+	data := cqlDataMap{
+		jobErr.Hash(): {
+			partitionKeys: map[string][]any{
+				"pk0": {"abc"},
+				"pk1": {int32(7)},
+			},
+			mutationFragments: []json.RawMessage{json.RawMessage(`{"fragment":1}`)},
+			statements:        []json.RawMessage{json.RawMessage(`{"statement":1}`)},
+		},
+	}
+
+	// Send both oracle and test entries
+	ch <- statementChData{ty: stmtlogger.TypeOracle, Data: data, Error: jobErr}
+	ch <- statementChData{ty: stmtlogger.TypeTest, Data: data, Error: jobErr}
+
+	// Close the channel to let flusher finish
+	close(ch)
+
+	// Avoid a race where Wait could be called before wg.Add(1) in the goroutine.
+	// Instead, poll for file appearance with a timeout.
+	waitForFile := func(path string) {
+		deadline := time.Now().Add(2 * time.Second)
+		for {
+			if _, err := os.Stat(path); err == nil {
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("timed out waiting for file %s to be created", path)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	waitForFile(oraclePath)
+	waitForFile(testPath)
+
+	// Validate that both files contain exactly one valid JSON object each
+	validateJSONL := func(path string) {
+		// Because the file may be created before the line is written, loop until
+		// we observe a non-empty line or time out.
+		var lines []string
+		deadline := time.Now().Add(2 * time.Second)
+		for {
+			f, err := os.Open(path)
+			if err != nil {
+				t.Fatalf("failed to open statements file %s: %v", path, err)
+			}
+
+			scanner := bufio.NewScanner(f)
+			lines = lines[:0]
+			for scanner.Scan() {
+				line := strings.TrimSpace(scanner.Text())
+				if line != "" {
+					lines = append(lines, line)
+				}
+			}
+			_ = f.Close()
+
+			if len(lines) > 0 {
+				break
+			}
+			if time.Now().After(deadline) {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		if len(lines) != 1 {
+			t.Fatalf("expected exactly 1 JSONL line in %s, got %d", path, len(lines))
+		}
+
+		var out Line
+		if err := json.Unmarshal([]byte(lines[0]), &out); err != nil {
+			t.Fatalf("invalid JSON in %s: %v\nline: %s", path, err, lines[0])
+		}
+
+		if out.Query != jobErr.Query {
+			t.Fatalf("unexpected query in %s: got %q want %q", path, out.Query, jobErr.Query)
+		}
+		if out.Message != jobErr.Message {
+			t.Fatalf("unexpected message in %s: got %q want %q", path, out.Message, jobErr.Message)
+		}
+		// Validate PKs copied through
+		if got := out.PartitionKeys["pk0"]; len(got) != 1 || got[0] != "abc" {
+			t.Fatalf("unexpected pk0 in %s: %#v", path, out.PartitionKeys["pk0"])
+		}
+		{
+			got := out.PartitionKeys["pk1"]
+			if len(got) != 1 {
+				t.Fatalf("unexpected pk1 length in %s: %#v", path, got)
+			}
+			var ok bool
+			switch v := got[0].(type) {
+			case float64:
+				ok = int(v) == 7
+			case int:
+				ok = v == 7
+			case int32:
+				ok = v == 7
+			case int64:
+				ok = v == 7
+			case uint:
+				ok = int(v) == 7
+			case uint32:
+				ok = int(v) == 7
+			case uint64:
+				ok = int(v) == 7
+			default:
+				ok = false
+			}
+			if !ok {
+				t.Fatalf("unexpected pk1 in %s: %#v", path, out.PartitionKeys["pk1"])
+			}
+		}
+
+		if len(out.MutationFragments) != 1 || string(out.MutationFragments[0]) != `{"fragment":1}` {
+			t.Fatalf("unexpected mutationFragments in %s: %s", path, string(out.MutationFragments[0]))
+		}
+		if len(out.Statements) != 1 || string(out.Statements[0]) != `{"statement":1}` {
+			t.Fatalf("unexpected statements in %s: %s", path, string(out.Statements[0]))
+		}
+	}
+
+	validateJSONL(oraclePath)
+	validateJSONL(testPath)
+}

--- a/pkg/stmtlogger/scylla/scylla_unit_test.go
+++ b/pkg/stmtlogger/scylla/scylla_unit_test.go
@@ -279,7 +279,7 @@ func TestStatementChData_Structure(t *testing.T) {
 			name: "oracle type",
 			data: statementChData{
 				ty: stmtlogger.TypeOracle,
-				Data: map[[32]byte]cqlData{
+				Data: cqlDataMap{
 					{1}: {
 						partitionKeys: map[string][]any{"pk0": {"key"}},
 						statements:    []json.RawMessage{json.RawMessage(`{"stmt":"SELECT"}`)},
@@ -296,7 +296,7 @@ func TestStatementChData_Structure(t *testing.T) {
 			name: "test type",
 			data: statementChData{
 				ty: stmtlogger.TypeTest,
-				Data: map[[32]byte]cqlData{
+				Data: cqlDataMap{
 					{2}: {
 						partitionKeys: map[string][]any{"pk0": {"key2"}},
 					},


### PR DESCRIPTION
1. `map[[32]byte]cqlData` cannot safely serialize to JSON, as `[]byte` is not always a valid string, so current fix is to use hex encoded map (`map[string]cqlData`)
2. `MUTATION_FRAGMENTS` are not working with `SELECT JSON`, reverting back to regular `SELECT`

Close #565 