### PR TITLE
Fix for Overwritten property

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,5 +1,4 @@
 export default {
-  parserPreset: 'conventional-changelog-atom',
   formatter: '@commitlint/format',
   rules: {
     "header-max-length": [2, "always", 120],


### PR DESCRIPTION
To fix the problem, remove the duplicate property definition so that only one `parserPreset` property is defined. Review what the intended configuration is: sometimes, a string is sufficient; other times, an object is required (with more nested options). In this case, since the latter property is an object with `parserOpts`, and is the definitive value, we should remove the first occurrence (`parserPreset: 'conventional-changelog-atom'` on line 2). Nothing else needs to be changed—just delete the first definition so there's only one `parserPreset` object with its nested settings.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._