### PR TITLE
fix(observers): missing IP in the statement logger

### DIFF
--- a/pkg/store/observers.go
+++ b/pkg/store/observers.go
@@ -16,7 +16,9 @@ package store
 
 import (
 	"context"
+	"net"
 	"slices"
+	"strconv"
 	"sync"
 
 	"github.com/gocql/gocql"
@@ -129,7 +131,7 @@ func (c *ClusterObserver) ObserveBatch(ctx context.Context, batch gocql.Observed
 	if data == nil {
 		return
 	}
-	instance := batch.Host.ConnectAddressAndPort()
+	instance := net.JoinHostPort(batch.Host.ConnectAddress().String(), strconv.Itoa(batch.Host.Port()))
 
 	var errStr string
 
@@ -178,7 +180,8 @@ func (c *ClusterObserver) ObserveQuery(ctx context.Context, query gocql.Observed
 		return
 	}
 
-	instance := query.Host.ListenAddress().String()
+	instance := net.JoinHostPort(query.Host.ConnectAddress().String(), strconv.Itoa(query.Host.Port()))
+
 	var errStr string
 	if query.Err != nil {
 		metrics.GoCQLQueryErrors.WithLabelValues(string(c.clusterName), instance, query.Err.Error()).Inc()


### PR DESCRIPTION
Listening Address is not always populated in the driver, leading to garbage data shown in the Statement logger. This was changed due to the `ConnectAddressAndPort` being really slow when multiple requests are accessing the same Node. Since we want to know in the statement logger, what was the coordinator node for Query, there was no way to cache this solution and avoid this Lock Contention. This is why I changed it on master to be `ListenAddress()`. But after implementing the Fix in the driver, I've found the way to circumvent this `ConnectAddressAndPort` and manually construct it, since ConnectAddress and Port are available as public functions. 

As we cannot use the `Host.ConnectAddressAndPort()` in the query observer due to heavy Write Lock contention, This is the implementation of the proposed solution in the https://github.com/scylladb/gocql/pull/650

We need this fix in even after the driver team merges the PR, since we are stuck on this driver version (v1.6.x) for at least 2.2 gemini version, and upgrade to the new v1.7.x driver contains breaking changes and requires more work. This upgrade is planned for v2.3 gemini

Close #590 