### PR TITLE
.github/workflows/go.yml: Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,6 @@
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/gemini/security/code-scanning/14](https://github.com/scylladb/gemini/security/code-scanning/14)

In general, the fix is to add an explicit `permissions:` block to the workflow (preferably at the top level so it applies to all jobs) that restricts the `GITHUB_TOKEN` to the minimal scopes required. For this workflow, the steps only need to read the repository contents; they do not push commits, modify issues, or interact with other GitHub APIs in a write capacity. Therefore, `contents: read` at the workflow level is an appropriate least-privilege configuration.

Concretely, in `.github/workflows/go.yml`, add a top-level `permissions:` block right after the `name: Go` line. This will apply to all jobs that don’t override permissions. The block should set `contents: read` as recommended by the CodeQL message. No imports or other code changes are needed since this is pure workflow configuration. No changes to the existing job configuration, steps, or timeouts are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
