### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   goreleaser:
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/gemini/security/code-scanning/11](https://github.com/scylladb/gemini/security/code-scanning/11)

In general, to fix this class of problem you explicitly set `permissions` at either the workflow root or the individual job level, granting only the scopes needed. For this workflow, the job needs to read the repository contents (for `actions/checkout`) but does not need to write to the repo, manage issues, or change PRs. It authenticates to Docker Hub using secrets, not `GITHUB_TOKEN`, so repository permissions can be restricted to read-only.

The single best fix with no functional change is to add a `permissions` block specifying `contents: read`. Since there is only one job (`goreleaser`), you can add this block under the job definition. Concretely, in `.github/workflows/docker.yml`, under `jobs: goreleaser:`, insert:

```yaml
permissions:
  contents: read
```

so that it appears before `runs-on:`. No additional imports, methods, or other definitions are needed; it’s just a YAML configuration change within this workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
