### PR TITLE
ci(renovate): show semver versions in GitHub Actions digest PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
+  "commitBodyTable": true,
   "schedule": [
     "every weekend"
   ],


### PR DESCRIPTION
Add `helpers:pinGitHubActionDigestsToSemver` preset so Renovate extracts
the actual semver tag (e.g. v6.0.2 → v6.0.3) when updating SHA-pinned
GitHub Actions, instead of only showing opaque digest fragments.

Enable `commitBodyTable` to include a version table in commit messages
showing datasource, package, and version change.

This keeps SHA pinning for security while making digest update PRs
informative with proper version context, release notes, and diffs.

Mirrors: https://github.com/scylladb/scylla-cluster-tests/commit/b2b9a495d606d9555532b815706aadd7311d4147