### PR TITLE
fix(go.mod): unbreak Renovate gomod dependency detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,6 @@ go 1.25.0
 
 replace github.com/gocql/gocql => github.com/scylladb/gocql v1.18.3
 
-exclude (
-	google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250818200422-3122310a409c
-)
-
 require (
 	github.com/gocql/gocql v1.8.0
 	github.com/google/go-cmp v0.7.0
@@ -103,6 +98,11 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	mvdan.cc/gofumpt v0.9.1 // indirect
+)
+
+exclude (
+	google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250818200422-3122310a409c
 )
 
 tool (


### PR DESCRIPTION
## Summary
Renovate's Dependency Dashboard was only detecting 2 gomod dependencies (`go` directive + `github.com/scylladb/gocql` via `replace`) instead of the ~90 actually in `go.mod`. This meant Renovate was silently missing almost every Go dependency update.

Root cause: Renovate's `gomod` manager stops parsing the file when an `exclude (...)` block appears before a `require (...)` block. Confirmed locally with `renovate --platform=local --dry-run=extract` against minimal repros — moving `exclude` after `require` (or using single-line `exclude` statements) fixes extraction every time.

## Changes
- Moved the `exclude (...)` block in `go.mod` to after the `require` blocks (before `tool (...)`). No dependency versions changed, no semantic change to the module.

## Test plan
- [x] `renovate-config-validator renovate.json` passes
- [x] `renovate --dry-run=extract` locally: gomod dep count went from 2 → 92 after the fix
- [x] `go build ./...` succeeds
- [x] `go vet ./...` shows the same single pre-existing, unrelated failure as before this change (`workload_test.go`, `testutils.ScyllaContainer.TestPort`)