### PR TITLE
fix: harden asymmetric-write compensation and mutation-ratio filtering

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -51,6 +51,77 @@ curl http://localhost:9090/metrics
 | `validated_rows` | Counter | Successfully validated rows by table |
 | `execution_errors` | Counter | Execution errors by type |
 
+### Dual-Write Divergence
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `mutation_asymmetric_acks_total` | Counter | Dual-write mutations acknowledged by one cluster but not the other |
+| `mutation_compensation_failures_total` | Counter | Compensating whole-partition `DELETE`s that failed, by the cluster whose delete failed |
+
+Labels:
+
+| Label | Values | Meaning |
+|-------|--------|---------|
+| `outcome` | `compensated` | A best-effort whole-partition `DELETE` was issued to **both** clusters, making the partition deterministically empty regardless of which side actually committed. The run continues and the partition stays valid. |
+| `outcome` | `uncompensated` | Compensation did not apply or failed. The affected partitions were marked invalid so validation skips them. |
+| `acked_store` | `test` / `oracle` | The cluster that **did** acknowledge the write. |
+
+**This counts acknowledgements, not confirmed divergence.** A non-nil error from a
+store proves it did not acknowledge; it does *not* prove the write was never
+applied, because a timed-out server may have committed and lost the response.
+Treat a non-zero value as "the dual write may not have stayed symmetric — verify
+before trusting validation results from this run", **not** as "the clusters are
+definitely inconsistent". The metric is derived from gemini's own per-store
+bookkeeping, not from the statement log, so it stays accurate even when the
+logger is stalled or back-pressured.
+
+Only emitted when an oracle cluster is configured.
+
+Example alert — any asymmetry at all is worth a look, since a healthy run should
+produce none:
+
+```promql
+sum(increase(gemini_mutation_asymmetric_acks_total[10m])) by (outcome, acked_store) > 0
+```
+
+Uncompensated asymmetry is the more serious case (partitions were dropped from
+validation coverage rather than repaired):
+
+```promql
+sum(rate(gemini_mutation_asymmetric_acks_total{outcome="uncompensated"}[5m])) > 0
+```
+
+#### Compensation failures
+
+`mutation_compensation_failures_total` is the companion signal. Compensation
+runs after a write times out and issues a whole-partition `DELETE` to **both**
+clusters, forcing the partition to a known-empty state so an ambiguous timeout
+cannot become a divergence. A failure means that collapse did not happen — the
+partition may hold a committed-but-timed-out write on one cluster and nothing on
+the other.
+
+This matters even when the acknowledgement metric stays flat. If *both* original
+writes time out, the two success flags are equal and no asymmetric ack is
+recorded, yet each server may independently have committed. A half-successful
+compensation in that state leaves the clusters genuinely different. Gemini marks
+those partitions invalid so validation skips them, so this never produces a false
+bug report — but a sustained non-zero rate means the run is steadily losing
+partition coverage and its results are correspondingly weaker.
+
+Invalidation is driven by the asymmetry itself, not by the error kind: a write
+that commits on one cluster and fails on the other with any error — timeout,
+`Unavailable`, `WriteFailure` — takes its partitions out of validation coverage.
+Only the *error accounting* distinguishes timeouts (exempt, to keep a slow
+runner from exhausting the error budget) from real failures (charged).
+
+```promql
+sum(rate(gemini_mutation_compensation_failures_total[5m])) by (store) > 0
+```
+
+> **Note on naming:** metric names in the tables above are written without the
+> registry prefix. All gemini metrics are exported with a `gemini_` prefix, so
+> the counter above is queried as `gemini_mutation_asymmetric_acks_total`.
+
 ### Statement Logger
 
 | Metric | Type | Description |

--- a/docs/statement-ratio.md
+++ b/docs/statement-ratio.md
@@ -98,6 +98,50 @@ Controls the distribution of data modification operations:
 
 **Note**: These three values must sum to 1.0
 
+##### Renormalization when a type is filtered
+
+Some phases exclude a mutation type entirely — most importantly **warmup** and
+any no-delete worker, which filter `delete` so the warmup phase populates data
+without removing it.
+
+When a type is filtered, its probability mass is redistributed
+**proportionally across the remaining types**, preserving their configured
+ratio to one another. It is *not* reassigned to any single type.
+
+With `insert: 0.2, update: 0.3, delete: 0.5`, a worker that filters `delete`
+generates:
+
+| Type | Configured | Effective (delete filtered) |
+|------|-----------|------------------------------|
+| `insert` | 0.2 | 0.2 / (0.2 + 0.3) = **0.4** |
+| `update` | 0.3 | 0.3 / (0.2 + 0.3) = **0.6** |
+
+A type configured to `0.0` is never generated, even when it is the only type
+left after filtering. Setting `insert: 0.0` means no INSERTs — including during
+warmup.
+
+> ⚠️ **Behaviour change.** Earlier versions dumped the filtered mass onto
+> `insert` instead of redistributing it, which skewed the insert:update
+> proportion during warmup and could generate INSERTs even with `insert: 0.0`.
+> Correcting this shifts the effective warmup mix for **every** configuration —
+> with the defaults, from ≈0.75/0.25 to ≈0.737/0.263 insert:update. Expect a
+> corresponding shift in run baselines.
+
+##### Configurations with no valid candidate
+
+Because the three ratios only have to sum to 1.0 — there is no per-type minimum —
+it is possible to configure a workload where a filtering phase has nothing left
+to generate. For example `insert: 0.0, update: 0.0, delete: 1.0` is accepted at
+startup, but a warmup worker filters `delete` and is left with only zero-weight
+types.
+
+Rather than silently substituting a statement type the phase excluded, gemini
+**terminates the mutation worker** with a clear error and stops the run. The
+condition is permanent — the ratios and the phase's filter are both fixed for
+the life of the run — so no retry could recover. If you hit this, either give
+`insert` or `update` a non-zero ratio, or do not run a warmup / no-delete phase
+with a delete-only configuration.
+
 #### Insert Subtypes (`insert_subtypes`)
 
 Fine-grained control over INSERT statement types:

--- a/pkg/jobs/mutation.go
+++ b/pkg/jobs/mutation.go
@@ -114,33 +114,64 @@ func (m *Mutation) run(ctx context.Context) error {
 		return context.Canceled
 	}
 
+	var mutErr *store.MutationError
+	isMutationErr := errors.As(err, &mutErr)
+
+	// Whether the partition is still trustworthy is decided FIRST, independent of
+	// how the write failed. Nesting this under the deadline check would let every
+	// non-timeout asymmetric failure through: if the test store commits and the
+	// oracle returns, say, Unavailable, the write is just as asymmetric as a
+	// timeout, but the error is not DeadlineExceeded, so the partition would stay
+	// in validation coverage and gemini would later report its own divergence as a
+	// product bug.
+	//
+	// Two independent reasons to distrust the partition:
+	//
+	//   1. Asymmetric acknowledgement — one cluster took the write and the other
+	//      did not, so their contents may differ. OracleStoreSuccess is only set
+	//      true when an oracle is configured (see delegatingStore.Mutate), so this
+	//      is safe when oracleStore == nil.
+	//   2. Failed compensation — the compensating DELETE did not fully succeed.
+	//      This one is NOT implied by the flags: when both original writes time
+	//      out the flags are equal (both false) even though each server may
+	//      independently have committed. Compensation is what collapses that
+	//      ambiguity, so if it half-succeeds the clusters can genuinely differ
+	//      while the flags still look symmetric.
+	if isMutationErr &&
+		(mutErr.OracleStoreSuccess != mutErr.TestStoreSuccess || mutErr.CompensationFailed) {
+		// Whether the clusters actually diverged is UNKNOWN — a timed-out server
+		// may have applied the write and lost the response — so this is reported as
+		// a possible divergence, not a confirmed one. Claiming otherwise would give
+		// operators a false corruption signal. Surfaced at Warn rather than
+		// accumulating silently, and the affected partitions are marked invalid so
+		// validation skips them instead of reporting a mismatch gemini caused.
+		m.logger.Warn("write left partitions in an unknown state, marking them invalid",
+			zap.Int("partition_count", len(mutateStmt.PartitionKeys)),
+			zap.String("query_type", mutateStmt.QueryType.String()),
+			zap.Bool("asymmetric_ack", mutErr.TestStoreSuccess != mutErr.OracleStoreSuccess),
+			zap.Bool("compensation_failed", mutErr.CompensationFailed),
+			zap.Bool("test_store_success", mutErr.TestStoreSuccess),
+			zap.Bool("oracle_store_success", mutErr.OracleStoreSuccess),
+			zap.Bool("timed_out", errors.Is(err, context.DeadlineExceeded)),
+		)
+
+		for i := range mutateStmt.PartitionKeys {
+			m.statement.MarkInvalid(&mutateStmt.PartitionKeys[i])
+		}
+	}
+
 	// For context deadline expirations (CQL RequestTimeout or job shutdown), don't
 	// count as data errors. This covers both the raw error and MutationError whose
 	// FinalError is DeadlineExceeded (all retries timed out on a slow CI runner).
-	// Exception: if the stores ended up asymmetric (one committed, the other timed
-	// out on all retries), mark the affected partitions invalid so the validation
-	// phase skips them rather than reporting a false divergence.
-	// OracleStoreSuccess is only set true when an oracle is configured (see
-	// delegatingStore.Mutate), so this check is safe when oracleStore == nil.
+	// Any partition invalidation the timeout warranted has already happened above.
 	if errors.Is(err, context.DeadlineExceeded) {
-		var mutErr *store.MutationError
-		if errors.As(err, &mutErr) && mutErr.OracleStoreSuccess != mutErr.TestStoreSuccess {
-			for i := range mutateStmt.PartitionKeys {
-				m.logger.Debug("marking partition invalid due to asymmetric write timeout",
-					zap.String("partition_id", mutateStmt.PartitionKeys[i].ID.String()),
-					zap.Bool("test_store_success", mutErr.TestStoreSuccess),
-					zap.Bool("oracle_store_success", mutErr.OracleStoreSuccess),
-				)
-				m.statement.MarkInvalid(&mutateStmt.PartitionKeys[i])
-			}
-		}
 		return nil
 	}
 
 	// If this is a comprehensive mutation error (all retries failed for a non-timeout
-	// reason), surface it as a write error.
-	var mutationFailErr *store.MutationError
-	if errors.As(err, &mutationFailErr) {
+	// reason), surface it as a write error. Invalidation above and error accounting
+	// here are independent: an asymmetric non-timeout failure needs BOTH.
+	if isMutationErr {
 		je := &joberror.JobError{
 			Err:       err,
 			Timestamp: time.Now(),
@@ -210,6 +241,21 @@ func (m *Mutation) Do(ctx context.Context) error {
 
 		if errors.Is(err, context.Canceled) {
 			return nil
+		}
+
+		if errors.Is(err, statements.ErrNoMutationCandidates) {
+			// Permanent misconfiguration: the configured ratios leave nothing
+			// this worker is allowed to generate (e.g. a no-delete worker on a
+			// table whose DeleteRatio is 1.0). Retrying can never recover, so
+			// stop loudly instead of spinning on the error forever.
+			m.logger.Error("mutation worker cannot generate any statement under its filter",
+				zap.String("table", m.table.Name),
+				zap.Bool("deletes_enabled", m.delete),
+				zap.Error(err),
+			)
+			m.stopFlag.SetSoft(true)
+
+			return err
 		}
 
 		if errors.Is(err, ErrNoStatement) || errors.Is(err, statements.ErrNoTrackedRows) {

--- a/pkg/jobs/mutation_invalidation_test.go
+++ b/pkg/jobs/mutation_invalidation_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 ScyllaDB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jobs
+
+import (
+	"context"
+	"errors"
+	"math/rand/v2"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/scylladb/gemini/pkg/joberror"
+	"github.com/scylladb/gemini/pkg/partitions"
+	"github.com/scylladb/gemini/pkg/statements"
+	"github.com/scylladb/gemini/pkg/status"
+	"github.com/scylladb/gemini/pkg/store"
+	"github.com/scylladb/gemini/pkg/typedef"
+)
+
+// invalidationRecorder is a partitions.Interface stub that records MarkInvalid
+// calls and hands out usable partition keys, so a real statements.Generator can
+// build a mutation statement on top of it.
+type invalidationRecorder struct {
+	invalid []uuid.UUID
+	mu      sync.Mutex
+}
+
+func (g *invalidationRecorder) MarkInvalid(keys *typedef.PartitionKeys) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.invalid = append(g.invalid, keys.ID)
+
+	return true
+}
+
+func (g *invalidationRecorder) count() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	return len(g.invalid)
+}
+
+func (g *invalidationRecorder) keys() typedef.PartitionKeys {
+	return typedef.PartitionKeys{
+		ID:     uuid.New(),
+		Values: typedef.NewValuesFromMap(map[string][]any{"pk1": {int32(1)}}),
+	}
+}
+
+func (g *invalidationRecorder) Next() typedef.PartitionKeys            { return g.keys() }
+func (g *invalidationRecorder) Get(_ uint64) typedef.PartitionKeys     { return g.keys() }
+func (g *invalidationRecorder) Extend() typedef.PartitionKeys          { return g.keys() }
+func (g *invalidationRecorder) ReplaceNext() typedef.PartitionKeys     { return g.keys() }
+func (g *invalidationRecorder) Replace(_ uint64) typedef.PartitionKeys { return g.keys() }
+
+func (g *invalidationRecorder) Stats() partitions.Stats                    { return partitions.Stats{} }
+func (g *invalidationRecorder) ReplaceWithoutOld(_ uint64)                 {}
+func (g *invalidationRecorder) ReplaceNextWithoutOld()                     {}
+func (g *invalidationRecorder) Deleted() <-chan typedef.PartitionKeys      { return nil }
+func (g *invalidationRecorder) ValidationSuccess(_ *typedef.PartitionKeys) {}
+func (g *invalidationRecorder) ValidationFailure(_ *typedef.PartitionKeys) {}
+func (g *invalidationRecorder) ValidationStats(_ uuid.UUID) (uint64, uint64, uint64, []uint64, uint64) {
+	return 0, 0, 0, nil, 0
+}
+func (g *invalidationRecorder) IsInvalid(_ uint64) bool          { return false }
+func (g *invalidationRecorder) InvalidCount() uint64             { return 0 }
+func (g *invalidationRecorder) TrackRow(_ partitions.TrackedRow) {}
+func (g *invalidationRecorder) RowTrackerFillRatio() float64     { return 0 }
+func (g *invalidationRecorder) PopTrackedRow() (partitions.TrackedRow, bool) {
+	return partitions.TrackedRow{}, false
+}
+func (g *invalidationRecorder) TrackedRowCount() uint64 { return 0 }
+func (g *invalidationRecorder) Len() uint64             { return 10 }
+func (g *invalidationRecorder) Close()                  {}
+
+var _ partitions.Interface = (*invalidationRecorder)(nil)
+
+// mutationErrStore returns a fixed error from Mutate.
+type mutationErrStore struct {
+	mockStore
+
+	err error
+}
+
+func (m *mutationErrStore) Mutate(context.Context, *typedef.Stmt) error { return m.err }
+
+// TestMutationRun_AsymmetricWriteInvalidatesRegardlessOfErrorKind pins that the
+// partition-invalidation decision does not depend on HOW the write failed.
+//
+// The regression: the invalidation used to live inside an
+// `errors.Is(err, context.DeadlineExceeded)` branch. An asymmetric write that
+// failed for any other reason — test store commits, oracle returns Unavailable,
+// say — skipped it entirely, was converted straight to a JobError, and left the
+// partition in validation coverage. The two clusters genuinely differ at that
+// point, so validation later reports a divergence gemini itself produced.
+//
+// A timeout is not special here: what makes the partition untrustworthy is the
+// asymmetry, not the error kind.
+func TestMutationRun_AsymmetricWriteInvalidatesRegardlessOfErrorKind(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		err  error
+		name string
+		// run() reports a data error by returning a *joberror.JobError, which Do()
+		// then charges against the error budget. Timeouts are deliberately exempt
+		// (infrastructure signal: a slow CI runner would otherwise exhaust the
+		// budget) and yield a nil error instead. Invalidation and error accounting
+		// are independent decisions, and hoisting the former must not disturb the
+		// latter.
+		wantJobError bool
+	}{
+		{
+			name:         "non-timeout error",
+			err:          errors.New("Cannot achieve consistency level QUORUM"),
+			wantJobError: true,
+		},
+		{
+			name:         "timeout error",
+			err:          context.DeadlineExceeded,
+			wantJobError: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gen := &invalidationRecorder{}
+
+			table := &typedef.Table{
+				Name:          "t",
+				PartitionKeys: typedef.Columns{{Name: "pk1", Type: typedef.TypeInt}},
+				Columns:       typedef.Columns{{Name: "c1", Type: typedef.TypeInt}},
+			}
+
+			controller, err := statements.NewRatioController(
+				statements.DefaultStatementRatios(),
+				rand.New(rand.NewChaCha8([32]byte{})),
+			)
+			require.NoError(t, err)
+
+			vrc := typedef.ValueRangeConfig{}
+
+			// Asymmetric: the test store committed, the oracle did not.
+			mutErr := &store.MutationError{
+				TestStoreSuccess:   true,
+				OracleStoreSuccess: false,
+			}
+			mutErr.Finalize(tc.err)
+
+			m := &Mutation{
+				table:     table,
+				schema:    &typedef.Schema{Keyspace: typedef.Keyspace{Name: "ks"}},
+				logger:    zap.NewNop(),
+				status:    status.NewGlobalStatus(10),
+				generator: gen,
+				store:     &mutationErrStore{err: mutErr},
+				statement: statements.New(
+					"ks", gen, table,
+					rand.New(rand.NewChaCha8([32]byte{})),
+					&vrc, controller, false,
+				),
+			}
+
+			runErr := m.run(t.Context())
+
+			assert.Positive(t, gen.count(),
+				"an asymmetric write must invalidate its partitions no matter which error ended it")
+
+			var jobErr *joberror.JobError
+			assert.Equal(t, tc.wantJobError, errors.As(runErr, &jobErr),
+				"hoisting the invalidation must not change which errors are charged to the budget")
+		})
+	}
+}

--- a/pkg/jobs/mutation_nocandidates_test.go
+++ b/pkg/jobs/mutation_nocandidates_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 ScyllaDB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jobs
+
+import (
+	"math/rand/v2"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/scylladb/gemini/pkg/statements"
+	"github.com/scylladb/gemini/pkg/status"
+	"github.com/scylladb/gemini/pkg/stop"
+	"github.com/scylladb/gemini/pkg/typedef"
+)
+
+// noCandidateRatios is the one production configuration that can starve a
+// mutation worker: DeleteRatio 1.0 passes validation (the three only have to
+// sum to 1.0 -- there is no per-type floor), and a warmup / no-delete worker
+// filters DELETE, leaving every surviving type at zero weight.
+func noCandidateRatios() statements.Ratios {
+	r := statements.DefaultStatementRatios()
+	r.MutationRatios.InsertRatio = 0.0
+	r.MutationRatios.UpdateRatio = 0.0
+	r.MutationRatios.DeleteRatio = 1.0
+
+	return r
+}
+
+// TestMutationDo_NoCandidates_StopsInsteadOfSpinning pins the terminal handling
+// of statements.ErrNoMutationCandidates in Mutation.Do.
+//
+// The regression this guards against is subtle: Do's loop `continue`s on any
+// error it does not specifically recognise. ErrNoMutationCandidates is
+// permanent -- the ratios and the worker's filter are both fixed for the life
+// of the run, so no retry can ever succeed -- which means falling through would
+// spin the worker at full speed forever, burning a core and emitting nothing.
+// Do must instead stop the run and surface the misconfiguration.
+func TestMutationDo_NoCandidates_StopsInsteadOfSpinning(t *testing.T) {
+	t.Parallel()
+
+	controller, err := statements.NewRatioController(
+		noCandidateRatios(),
+		rand.New(rand.NewChaCha8([32]byte{})),
+	)
+	require.NoError(t, err)
+
+	table := &typedef.Table{Name: "no_candidates"}
+	vrc := typedef.ValueRangeConfig{}
+
+	m := &Mutation{
+		table:  table,
+		logger: zap.NewNop(),
+		// delete == false is the warmup / no-delete worker: it filters
+		// StatementTypeDelete, which is the only type carrying any weight here.
+		delete:   false,
+		stopFlag: stop.NewFlag(t.Name()),
+		// Populated so that a regression which drops the terminal branch falls
+		// through into the real hot-spin loop and trips the timeout below with a
+		// useful message, rather than crashing on a nil status and burying the
+		// actual diagnosis under a stack trace.
+		status: status.NewGlobalStatus(10),
+		statement: statements.New(
+			"ks",
+			nil, // never reached: the ratio check fails before any partition access
+			table,
+			rand.New(rand.NewChaCha8([32]byte{})),
+			&vrc,
+			controller,
+			false,
+		),
+	}
+
+	// Guard against the hot-spin regression itself: if Do ever goes back to
+	// continue-ing on this error it will not return, and the test must fail with
+	// a clear diagnosis rather than hanging until the whole package times out.
+	done := make(chan error, 1)
+	go func() { done <- m.Do(t.Context()) }()
+
+	select {
+	case doErr := <-done:
+		require.ErrorIs(t, doErr, statements.ErrNoMutationCandidates,
+			"Do must surface the misconfiguration rather than swallowing it")
+	case <-time.After(10 * time.Second):
+		t.Fatal("Mutation.Do did not return: it is spinning on ErrNoMutationCandidates instead of stopping")
+	}
+
+	assert.True(t, m.stopFlag.IsHardOrSoft(),
+		"Do must set the stop flag so sibling workers wind down too")
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -187,6 +187,55 @@ var (
 		},
 	)
 
+	// MutationAsymmetricAcksTotal counts dual-write mutations acknowledged by one
+	// cluster but not the other, detected from gemini's own per-store success
+	// bookkeeping (MutationError.TestStoreSuccess vs OracleStoreSuccess) rather
+	// than from the lossy statement log.
+	//
+	// This measures ACKNOWLEDGEMENTS, not commits, and the distinction is
+	// load-bearing: when the other store failed with a timeout its commit state is
+	// genuinely unknown — the server may well have applied the write and lost the
+	// response. Reporting that as a confirmed divergence would hand operators
+	// exactly the false-positive corruption signal this metric exists to avoid. A
+	// non-zero value means "the dual write may not have stayed symmetric" — worth
+	// investigating before trusting validation results from the same run — not
+	// "the clusters are definitely inconsistent".
+	//
+	// Labels: "outcome" is how the asymmetry was resolved (compensated = a
+	// best-effort whole-partition DELETE was issued to both clusters, which makes
+	// the partition deterministically empty regardless of which side actually
+	// committed; uncompensated = the affected partitions were marked invalid
+	// instead). "acked_store" is the cluster that did acknowledge. Only counted
+	// when an oracle cluster is configured.
+	MutationAsymmetricAcksTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mutation_asymmetric_acks_total",
+			Help: "Total dual-write mutations acknowledged by one cluster but not the other, " +
+				"by resolution outcome and acknowledging cluster. Possible divergence, not confirmed: " +
+				"a timed-out cluster may still have committed.",
+		},
+		[]string{"outcome", "acked_store"},
+	)
+
+	// MutationCompensationFailuresTotal counts compensating whole-partition
+	// DELETEs that failed, labelled by the cluster whose delete failed.
+	//
+	// Compensation runs after a write times out, to force the partition to a
+	// known-empty state on BOTH clusters so an ambiguous timeout cannot turn into
+	// a divergence. A failure here means that collapse did not happen: the
+	// partition may now hold a committed-but-timed-out write on one cluster and
+	// nothing on the other. The affected partitions are marked invalid so
+	// validation skips them, but a sustained non-zero rate means the run is losing
+	// partition coverage and its results are correspondingly less meaningful.
+	MutationCompensationFailuresTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "mutation_compensation_failures_total",
+			Help: "Total compensating whole-partition DELETEs that failed, by the cluster whose delete failed. " +
+				"Affected partitions are marked invalid and dropped from validation coverage.",
+		},
+		[]string{"store"},
+	)
+
 	// StatementLoggerMalformedTotal counts statement log items dropped by the
 	// committer because the number of partition-key values bound did not match
 	// the _logs INSERT arity (e.g. an item built with empty PartitionKeys.Values
@@ -311,6 +360,8 @@ func init() {
 		StatementLoggerOverflowItems,
 		StatementLoggerOverflowTotal,
 		StatementLoggerMalformedTotal,
+		MutationAsymmetricAcksTotal,
+		MutationCompensationFailuresTotal,
 		DeletedPartitionsHeapEvictions,
 		DeletedPartitionsSampledOut,
 		StatementLoggerFlushes,

--- a/pkg/services/workload_test.go
+++ b/pkg/services/workload_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build testing
+
 package services
 
 import (

--- a/pkg/statements/mutations.go
+++ b/pkg/statements/mutations.go
@@ -30,7 +30,12 @@ func (g *Generator) MutateStatement(ctx context.Context, generateDelete bool) (*
 		filterDeletes = []StatementType{StatementTypeDelete}
 	}
 
-	switch g.ratioController.GetMutationStatementType(filterDeletes...) {
+	stmtType, err := g.ratioController.GetMutationStatementType(filterDeletes...)
+	if err != nil {
+		return nil, err
+	}
+
+	switch stmtType {
 	case StatementTypeInsert:
 		if g.table.IsCounterTable() {
 			return g.Update(ctx)

--- a/pkg/statements/ratio.go
+++ b/pkg/statements/ratio.go
@@ -15,6 +15,7 @@
 package statements
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"slices"
@@ -239,18 +240,77 @@ func (c *RatioController) buildCDFs(ratios Ratios) {
 	}
 }
 
-// GetMutationStatementType returns a mutation statement type (Insert, Update, Delete) based on configured ratios
-func (c *RatioController) GetMutationStatementType(filter ...StatementType) StatementType {
-	r := c.random.Float64()
+// ErrNoMutationCandidates is returned by GetMutationStatementType when the
+// requested filter leaves no mutation type with non-zero probability mass —
+// e.g. every type was filtered, or the only surviving types have a ratio of
+// zero. There is no correct statement to generate in that case, so the caller
+// must handle it rather than receive an arbitrary (and possibly explicitly
+// excluded) type.
+var ErrNoMutationCandidates = errors.New(
+	"no mutation statement type available: every type with a non-zero ratio was filtered out",
+)
 
-	for i, cdf := range c.mutationCDF {
-		if r <= cdf && !slices.Contains(filter, StatementType(i)) {
-			return StatementType(i)
+// GetMutationStatementType picks a mutation statement type (insert/update/delete)
+// weighted by the configured ratios. Types passed in filter are excluded and
+// their probability mass is redistributed PROPORTIONALLY across the remaining
+// types rather than leaking into a hardcoded fallback.
+//
+// A filtered type is never returned. When no candidate survives the filter the
+// method reports ErrNoMutationCandidates instead of guessing: returning a type
+// the caller explicitly excluded would fabricate exactly the disallowed
+// statement (e.g. a DELETE during warmup) that the filter exists to prevent.
+//
+// The previous implementation walked the cumulative CDF and, when the matching
+// bucket was filtered, fell through to `return StatementTypeInsert`. That dumped
+// the entire filtered mass onto insert: when deletes were filtered (warmup /
+// no-delete modes) the configured insert:update proportion was silently skewed,
+// updates never received any of the freed delete mass, and inserts were
+// generated even when InsertRatio was zero. Redistributing over the surviving
+// weights fixes all three and generalizes to filtering any type.
+func (c *RatioController) GetMutationStatementType(filter ...StatementType) (StatementType, error) {
+	// Reconstruct per-type weights from the cumulative CDF and sum the mass of
+	// the non-filtered types.
+	var weights [MutationStatementsCount]float64
+	var total, prev float64
+	for i := range c.mutationCDF {
+		weights[i] = c.mutationCDF[i] - prev
+		prev = c.mutationCDF[i]
+		if !slices.Contains(filter, StatementType(i)) {
+			total += weights[i]
 		}
 	}
 
-	// Fallback (should not happen with valid CDFs)
-	return StatementTypeInsert
+	if total <= 0 {
+		return 0, ErrNoMutationCandidates
+	}
+
+	// Sample within the surviving mass, then walk the non-filtered types.
+	// Float64() is in [0,1) so r is in [0,total); the strict `r < acc` guard
+	// skips zero-weight types (e.g. InsertRatio == 0) instead of returning them.
+	r := c.random.Float64() * total
+	last := StatementTypeCount
+	var acc float64
+	for i := range weights {
+		if slices.Contains(filter, StatementType(i)) || weights[i] <= 0 {
+			continue
+		}
+
+		acc += weights[i]
+		if r < acc {
+			return StatementType(i), nil
+		}
+
+		last = StatementType(i)
+	}
+
+	// Unreachable unless floating-point accumulation leaves r >= acc on the
+	// final bucket. Fall back to the last surviving candidate — never a
+	// filtered or zero-weight one. total > 0 guarantees last was assigned.
+	if last == StatementTypeCount {
+		return 0, ErrNoMutationCandidates
+	}
+
+	return last, nil
 }
 
 // GetValidationStatementType returns a validation statement type (currently only Select)

--- a/pkg/statements/ratio_test.go
+++ b/pkg/statements/ratio_test.go
@@ -15,6 +15,7 @@
 package statements
 
 import (
+	"errors"
 	"math"
 	"math/rand/v2"
 	"testing"
@@ -206,7 +207,10 @@ func TestStatementTypeDistribution(t *testing.T) {
 	counts := make(map[StatementType]int)
 
 	for range samples {
-		stmtType := controller.GetMutationStatementType()
+		stmtType, sErr := controller.GetMutationStatementType()
+		if sErr != nil {
+			t.Fatalf("GetMutationStatementType: %v", sErr)
+		}
 		counts[stmtType]++
 	}
 
@@ -226,6 +230,124 @@ func TestStatementTypeDistribution(t *testing.T) {
 				stmtType, expectedCount, actualCount, diff*100)
 		}
 	}
+}
+
+// TestGetMutationStatementTypeFiltering verifies that filtering a mutation type
+// redistributes its probability mass PROPORTIONALLY across the surviving types
+// instead of dumping it onto insert. This is the warmup / no-delete path
+// (generateDelete == false filters StatementTypeDelete).
+func TestGetMutationStatementTypeFiltering(t *testing.T) {
+	t.Parallel()
+
+	newController := func(t *testing.T, insert, update, del float64) *RatioController {
+		t.Helper()
+		ratios := DefaultStatementRatios()
+		ratios.MutationRatios.InsertRatio = insert
+		ratios.MutationRatios.UpdateRatio = update
+		ratios.MutationRatios.DeleteRatio = del
+		c, err := NewRatioController(ratios, rand.New(rand.NewChaCha8([32]byte{})))
+		if err != nil {
+			t.Fatalf("NewRatioController: %v", err)
+		}
+		return c
+	}
+
+	const (
+		samples   = 100000
+		tolerance = 0.03 // relative
+	)
+
+	sample := func(t *testing.T, c *RatioController, filter ...StatementType) map[StatementType]int {
+		t.Helper()
+		counts := make(map[StatementType]int)
+		for range samples {
+			ty, err := c.GetMutationStatementType(filter...)
+			if err != nil {
+				t.Fatalf("GetMutationStatementType: %v", err)
+			}
+			counts[ty]++
+		}
+		return counts
+	}
+
+	assertFraction := func(t *testing.T, counts map[StatementType]int, ty StatementType, want float64) {
+		t.Helper()
+		got := float64(counts[ty]) / float64(samples)
+		if math.Abs(got-want) > tolerance {
+			t.Errorf("%s fraction: got %.3f, want ~%.3f", ty, got, want)
+		}
+	}
+
+	t.Run("filtering deletes gives updates their proportional share", func(t *testing.T) {
+		t.Parallel()
+		// Insert:Update:Delete = 0.2:0.3:0.5. With deletes filtered the freed 0.5
+		// must split proportionally: Insert 0.2/0.5=0.4, Update 0.3/0.5=0.6.
+		// The old fallback-to-insert behavior produced Insert≈0.7, Update≈0.3.
+		counts := sample(t, newController(t, 0.2, 0.3, 0.5), StatementTypeDelete)
+		if counts[StatementTypeDelete] != 0 {
+			t.Errorf("expected zero deletes when filtered, got %d", counts[StatementTypeDelete])
+		}
+		assertFraction(t, counts, StatementTypeInsert, 0.4)
+		assertFraction(t, counts, StatementTypeUpdate, 0.6)
+	})
+
+	t.Run("filtering deletes never fabricates inserts when InsertRatio is zero", func(t *testing.T) {
+		t.Parallel()
+		// Insert=0, Update=0.5, Delete=0.5. Filtering deletes must yield ONLY
+		// updates. The old code returned insert (via fallback) ~50% of the time.
+		counts := sample(t, newController(t, 0.0, 0.5, 0.5), StatementTypeDelete)
+		if counts[StatementTypeInsert] != 0 {
+			t.Errorf("expected zero inserts when InsertRatio==0, got %d", counts[StatementTypeInsert])
+		}
+		if counts[StatementTypeDelete] != 0 {
+			t.Errorf("expected zero deletes when filtered, got %d", counts[StatementTypeDelete])
+		}
+		assertFraction(t, counts, StatementTypeUpdate, 1.0)
+	})
+
+	t.Run("no filter preserves configured ratios", func(t *testing.T) {
+		t.Parallel()
+		counts := sample(t, newController(t, 0.2, 0.3, 0.5))
+		assertFraction(t, counts, StatementTypeInsert, 0.2)
+		assertFraction(t, counts, StatementTypeUpdate, 0.3)
+		assertFraction(t, counts, StatementTypeDelete, 0.5)
+	})
+
+	t.Run("filtering every type reports no candidates instead of returning one", func(t *testing.T) {
+		t.Parallel()
+		// Returning any type here would hand back a statement the caller
+		// explicitly excluded — the exact failure the filter exists to prevent.
+		c := newController(t, 0.2, 0.3, 0.5)
+		_, err := c.GetMutationStatementType(StatementTypeInsert, StatementTypeUpdate, StatementTypeDelete)
+		if !errors.Is(err, ErrNoMutationCandidates) {
+			t.Errorf("all-filtered: got err %v, want ErrNoMutationCandidates", err)
+		}
+	})
+
+	t.Run("filtering leaves only zero-weight types reports no candidates", func(t *testing.T) {
+		t.Parallel()
+		// Insert=0, Update=0.5, Delete=0.5. Filtering update+delete leaves only
+		// insert, which carries no probability mass — there is nothing to pick.
+		c := newController(t, 0.0, 0.5, 0.5)
+		_, err := c.GetMutationStatementType(StatementTypeUpdate, StatementTypeDelete)
+		if !errors.Is(err, ErrNoMutationCandidates) {
+			t.Errorf("zero-weight survivor: got err %v, want ErrNoMutationCandidates", err)
+		}
+	})
+
+	t.Run("delete-only ratios during warmup report no candidates", func(t *testing.T) {
+		t.Parallel()
+		// The production repro: Insert=0, Update=0, Delete=1 passes validation
+		// (the three sum to 1.0; there is no per-type floor), and the only caller
+		// filters DELETE whenever generateDelete is false. Every surviving type
+		// then has zero weight. Returning insert here would generate INSERTs on a
+		// table configured to produce none.
+		c := newController(t, 0.0, 0.0, 1.0)
+		got, err := c.GetMutationStatementType(StatementTypeDelete)
+		if !errors.Is(err, ErrNoMutationCandidates) {
+			t.Errorf("delete-only + filtered delete: got (%s, %v), want ErrNoMutationCandidates", got, err)
+		}
+	})
 }
 
 func TestInsertSubtypeDistribution(t *testing.T) {

--- a/pkg/stmtlogger/scylla/scylla_pairing_test.go
+++ b/pkg/stmtlogger/scylla/scylla_pairing_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 ScyllaDB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scylla
+
+import (
+	"fmt"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/samber/mo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scylladb/gemini/pkg/stmtlogger"
+	"github.com/scylladb/gemini/pkg/typedef"
+)
+
+// distinctItem builds an item whose statement AND values are unique to idx, so
+// that any bleed between the statement column and the values column (a mispair)
+// is detectable: a coherent bind always has statement[i] paired with values[i].
+func distinctItem(idx int) stmtlogger.Item {
+	return stmtlogger.Item{
+		Start:         stmtlogger.Time{Time: time.Unix(0, int64(idx))},
+		PartitionKeys: typedef.PartitionKeys{Values: typedef.NewValuesFromMap(map[string][]any{"pk0": {fmt.Sprintf("k%d", idx)}, "pk1": {idx}})},
+		Error:         mo.Right[error, string](""),
+		Statement:     fmt.Sprintf("UPDATE ks.tbl SET c%d=? WHERE pk0=? AND pk1=?", idx),
+		Host:          "127.0.0.1",
+		Type:          stmtlogger.TypeTest,
+		Values:        mo.Left[[]any, []byte]([]any{idx, fmt.Sprintf("v%d", idx)}),
+		Duration:      stmtlogger.Duration{Duration: time.Millisecond},
+		Attempt:       1,
+		GeminiAttempt: 1,
+		StatementType: typedef.InsertStatementType,
+	}
+}
+
+// checkCoherent verifies the bound row's partition-key, statement and values
+// columns all belong to the SAME item (idx) — the invariant that makes _logs
+// triage trustworthy. Layout (see cqlStatements.fillArgs):
+// [pk values...][Start][Type][Statement][Values][Host]...
+//
+// It reports a failure as an error rather than failing the test directly, so it
+// is safe to call from a worker goroutine: testify's require calls t.FailNow,
+// which Go permits only on the goroutine running the test function.
+func checkCoherent(out []any, pkLen, idx int) error {
+	want := distinctItem(idx)
+
+	wantPK := fmt.Sprintf("k%d", idx)
+	if gotPK, ok := out[0].(string); !ok || gotPK != wantPK {
+		return fmt.Errorf("idx %d: partition key bled from another item: got %v, want %q", idx, out[0], wantPK)
+	}
+
+	gotStmt, ok := out[pkLen+2].(string)
+	if !ok {
+		return fmt.Errorf("idx %d: statement column has type %T, want string", idx, out[pkLen+2])
+	}
+
+	if gotStmt != want.Statement {
+		return fmt.Errorf("idx %d: statement column bled from another item: got %q, want %q", idx, gotStmt, want.Statement)
+	}
+
+	gotValues, ok := out[pkLen+3].([]string)
+	if !ok {
+		return fmt.Errorf("idx %d: values column has type %T, want []string", idx, out[pkLen+3])
+	}
+
+	if wantValues := prepareValuesOptimized(want.Values); !slices.Equal(gotValues, wantValues) {
+		return fmt.Errorf("idx %d: values column bled from another item: got %v, want %v", idx, gotValues, wantValues)
+	}
+
+	return nil
+}
+
+// TestFillArgs_BufferReuseKeepsPairing mirrors the committer's held[idx] reuse:
+// one dst buffer is rebound across a long stream of distinct items. Each bound
+// row must carry its OWN statement and values — no residue from the prior item.
+func TestFillArgs_BufferReuseKeepsPairing(t *testing.T) {
+	t.Parallel()
+	pks := typedef.Columns{{Name: "pk0", Type: typedef.TypeText}, {Name: "pk1", Type: typedef.TypeInt}}
+	c := makeTestCQL(pks)
+	pkLen := pks.LenValues()
+
+	dst := make([]any, 0, c.argsCap())
+	for i := range 5000 {
+		var ok bool
+		dst, ok = c.fillArgs(dst, distinctItem(i))
+		require.True(t, ok)
+		require.NoError(t, checkCoherent(dst, pkLen, i))
+	}
+}
+
+// TestFillArgs_ConcurrentBindingIsCoherent runs many goroutines binding through
+// a SHARED *cqlStatements (as every committer worker does), each with its own
+// dst buffer (as held[idx] is per-worker). Run with -race: catches any shared
+// mutable state introduced into fillArgs/cqlStatements that would let one
+// goroutine's statement pair with another's values.
+func TestFillArgs_ConcurrentBindingIsCoherent(t *testing.T) {
+	t.Parallel()
+	pks := typedef.Columns{{Name: "pk0", Type: typedef.TypeText}, {Name: "pk1", Type: typedef.TypeInt}}
+	c := makeTestCQL(pks)
+	pkLen := pks.LenValues()
+
+	const workers = 16
+
+	// Workers must not assert: require/t.FailNow are only legal on the goroutine
+	// running the test function. Each worker reports its first incoherent bind
+	// back through a buffered channel and the parent does the asserting.
+	failures := make(chan error, workers)
+	start := make(chan struct{})
+
+	var wg sync.WaitGroup
+
+	wg.Add(workers)
+
+	for w := range workers {
+		go func(base int) {
+			defer wg.Done()
+
+			dst := make([]any, 0, c.argsCap())
+			<-start // release all workers together to maximise overlap
+
+			for i := range 2000 {
+				idx := base*1_000_000 + i
+
+				var ok bool
+
+				dst, ok = c.fillArgs(dst, distinctItem(idx))
+				if !ok {
+					failures <- fmt.Errorf("idx %d: fillArgs reported failure", idx)
+					return
+				}
+
+				if err := checkCoherent(dst, pkLen, idx); err != nil {
+					failures <- err
+					return
+				}
+			}
+		}(w)
+	}
+
+	close(start)
+	wg.Wait()
+	close(failures)
+
+	for err := range failures {
+		t.Error(err)
+	}
+}

--- a/pkg/store/asymmetric_write_test.go
+++ b/pkg/store/asymmetric_write_test.go
@@ -115,14 +115,21 @@ func TestIsOnlyTimeoutFailure(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // compensateStore is a fakeStore that counts mutate calls and can be made to fail.
+// It also records the ctx and timestamp of the last mutate so tests can assert
+// that compensation attaches ContextData (for statement logging) and threads the
+// caller's write timestamp through.
 type compensateStore struct {
-	muErr error
+	muErr   error
+	lastCtx atomic.Pointer[context.Context]
+	lastTS  atomic.Pointer[mo.Option[time.Time]]
 	fakeStore
 	muCalls atomic.Int64
 }
 
-func (c *compensateStore) mutate(_ context.Context, _ *typedef.Stmt, _ mo.Option[time.Time]) error {
+func (c *compensateStore) mutate(ctx context.Context, _ *typedef.Stmt, ts mo.Option[time.Time]) error {
 	c.muCalls.Add(1)
+	c.lastCtx.Store(&ctx)
+	c.lastTS.Store(&ts)
 	return c.muErr
 }
 
@@ -132,6 +139,9 @@ func TestCompensateAsymmetricWrite(t *testing.T) {
 	// Build a minimal Stmt with one partition key and real column metadata so
 	// buildPartitionDeleteStmt can produce a valid DELETE.
 	pkCol := typedef.ColumnDef{Name: "pk", Type: typedef.TypeInt}
+	// A fixed client-side write timestamp threaded through compensation; the
+	// compensating DELETE must reuse it so both clusters share one cutoff.
+	writeTS := mo.Some(time.Unix(1_700_000_000, 0).UTC())
 	vals := typedef.NewValuesFromMap(map[string][]any{"pk": {1}})
 	stmt := &typedef.Stmt{
 		PartitionKeys: []typedef.PartitionKeys{
@@ -157,10 +167,33 @@ func TestCompensateAsymmetricWrite(t *testing.T) {
 		ts := &compensateStore{}
 		os := &compensateStore{}
 		ds := makeDS(ts, os)
-		ok := ds.compensateAsymmetricWrite(stmt)
+		ok := ds.compensateAsymmetricWrite(stmt, writeTS)
 		assert.True(t, ok)
 		assert.Equal(t, int64(1), ts.muCalls.Load())
 		assert.Equal(t, int64(1), os.muCalls.Load())
+
+		// The caller's write timestamp is threaded through to both stores so the
+		// compensating DELETE lands in the same timestamp domain as the writes.
+		require.NotNil(t, ts.lastTS.Load())
+		assert.Equal(t, writeTS, *ts.lastTS.Load())
+		assert.Equal(t, writeTS, *os.lastTS.Load())
+
+		// ContextData is attached so the gocql observers log the compensating
+		// delete instead of silently skipping it (nil ContextData).
+		require.NotNil(t, ts.lastCtx.Load())
+		data := MustGetContextData(*ts.lastCtx.Load())
+		require.NotNil(t, data)
+		assert.Equal(t, typedef.DeleteWholePartitionType, data.Statement.QueryType)
+
+		// Tagged with the compensation sentinel on BOTH stores so post-mortem
+		// triage can tell these deletes apart from ordinary workload against the
+		// same partition. Attempt 0 would be indistinguishable from a genuine
+		// first-attempt delete, which is the whole reason for logging them.
+		assert.Equal(t, CompensationAttempt, data.GeminiAttempt)
+		require.NotNil(t, os.lastCtx.Load())
+		oracleData := MustGetContextData(*os.lastCtx.Load())
+		require.NotNil(t, oracleData)
+		assert.Equal(t, CompensationAttempt, oracleData.GeminiAttempt)
 	})
 
 	t.Run("test store fails → returns false", func(t *testing.T) {
@@ -168,7 +201,7 @@ func TestCompensateAsymmetricWrite(t *testing.T) {
 		ts := &compensateStore{muErr: errors.New("test-fail")}
 		os := &compensateStore{}
 		ds := makeDS(ts, os)
-		ok := ds.compensateAsymmetricWrite(stmt)
+		ok := ds.compensateAsymmetricWrite(stmt, writeTS)
 		assert.False(t, ok)
 		assert.Equal(t, int64(1), ts.muCalls.Load())
 	})
@@ -178,7 +211,7 @@ func TestCompensateAsymmetricWrite(t *testing.T) {
 		ts := &compensateStore{}
 		os := &compensateStore{muErr: errors.New("oracle-fail")}
 		ds := makeDS(ts, os)
-		ok := ds.compensateAsymmetricWrite(stmt)
+		ok := ds.compensateAsymmetricWrite(stmt, writeTS)
 		assert.False(t, ok)
 	})
 
@@ -186,7 +219,7 @@ func TestCompensateAsymmetricWrite(t *testing.T) {
 		t.Parallel()
 		ts := &compensateStore{}
 		ds := makeDS(ts, nil)
-		ok := ds.compensateAsymmetricWrite(stmt)
+		ok := ds.compensateAsymmetricWrite(stmt, writeTS)
 		assert.True(t, ok)
 		assert.Equal(t, int64(1), ts.muCalls.Load())
 	})
@@ -195,7 +228,7 @@ func TestCompensateAsymmetricWrite(t *testing.T) {
 		t.Parallel()
 		ts := &compensateStore{}
 		ds := makeDS(ts, nil)
-		ok := ds.compensateAsymmetricWrite(&typedef.Stmt{PartitionKeys: nil})
+		ok := ds.compensateAsymmetricWrite(&typedef.Stmt{PartitionKeys: nil}, writeTS)
 		assert.True(t, ok)
 		assert.Equal(t, int64(0), ts.muCalls.Load())
 	})
@@ -211,7 +244,7 @@ func TestCompensateAsymmetricWrite(t *testing.T) {
 			partitionKeyColumns: typedef.Columns{}, // empty
 			keyspaceAndTable:    "ks.t",
 		}
-		ok := ds.compensateAsymmetricWrite(stmt)
+		ok := ds.compensateAsymmetricWrite(stmt, writeTS)
 		// Empty partitionKeyColumns → compensation early-returns before any delete.
 		assert.True(t, ok)
 		assert.Equal(t, int64(0), ts.muCalls.Load())
@@ -230,7 +263,7 @@ func TestCompensateAsymmetricWrite(t *testing.T) {
 		ts := &compensateStore{}
 		os := &compensateStore{}
 		ds := makeDS(ts, os)
-		ok := ds.compensateAsymmetricWrite(multiStmt)
+		ok := ds.compensateAsymmetricWrite(multiStmt, writeTS)
 		assert.True(t, ok)
 		assert.Equal(t, int64(2), ts.muCalls.Load())
 		assert.Equal(t, int64(2), os.muCalls.Load())

--- a/pkg/store/ctx.go
+++ b/pkg/store/ctx.go
@@ -25,6 +25,15 @@ type QueryContextKey string
 
 const ContextDataKey QueryContextKey = "QueryContextData"
 
+// CompensationAttempt is the sentinel GeminiAttempt value stamped on the
+// compensating DELETEs issued by compensateAsymmetricWrite. Real attempts are
+// zero-based counters, so a negative value cannot collide with one: it makes a
+// compensation artifact distinguishable in _logs from ordinary generated
+// workload against the same partition. Without it a compensating delete is
+// indistinguishable from a genuine first-attempt delete (both attempt 0), which
+// defeats the point of logging it for post-mortem triage.
+const CompensationAttempt = -1
+
 type ContextData struct {
 	Statement     *typedef.Stmt
 	Timestamp     time.Time

--- a/pkg/store/delegating_store_test.go
+++ b/pkg/store/delegating_store_test.go
@@ -22,10 +22,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/samber/mo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/scylladb/gemini/pkg/metrics"
 	"github.com/scylladb/gemini/pkg/typedef"
 )
 
@@ -142,6 +144,99 @@ func TestDelegatingStore_Mutate_BothFail_ReturnsError(t *testing.T) {
 	stmt := typedef.SimpleStmt("DELETE FROM ks.t WHERE k=1", typedef.DeleteSingleRowType)
 	err := ds.Mutate(t.Context(), stmt)
 	require.Error(t, err)
+}
+
+// TestDelegatingStore_Mutate_PartialCompensationFlagsInvalidation pins the one
+// case the per-store success flags cannot express.
+//
+// When BOTH original writes time out, TestStoreSuccess and OracleStoreSuccess
+// are equal (both false) — yet each server may independently have committed,
+// because a timeout says nothing about whether the write applied. Compensation
+// exists to collapse that ambiguity by deleting the partition on both sides. If
+// it only half-succeeds (test erased, oracle not), the clusters are genuinely
+// different while the flags still look symmetric.
+//
+// Without CompensationFailed, mutation.run's `OracleStoreSuccess !=
+// TestStoreSuccess` check is false, MarkInvalid is never called, and the
+// partition stays in validation coverage — so gemini reports a divergence it
+// created itself. That is the exact false-positive class this change set exists
+// to eliminate.
+func TestDelegatingStore_Mutate_PartialCompensationFlagsInvalidation(t *testing.T) {
+	t.Parallel()
+
+	timeout := context.DeadlineExceeded
+	// Two attempts each (mutationRetries=1), then the compensating DELETE:
+	// it succeeds on test and fails on oracle, leaving the partition erased on
+	// one cluster and possibly still present on the other.
+	test := &fakeStore{nameStr: "test", mutateSeq: []error{timeout, timeout, nil}}
+	oracle := &fakeStore{
+		nameStr:   "oracle",
+		mutateSeq: []error{timeout, timeout, errors.New("compensating delete failed")},
+	}
+
+	ds := &delegatingStore{
+		inflight:            new(sync.WaitGroup),
+		testStore:           test,
+		oracleStore:         oracle,
+		mutationRetries:     1,
+		mutationRetrySleep:  1 * time.Millisecond,
+		minimumDelay:        1 * time.Millisecond,
+		partitionKeyColumns: typedef.Columns{{Name: "pk", Type: typedef.TypeInt}},
+		keyspaceAndTable:    "ks.t",
+	}
+
+	stmt := &typedef.Stmt{
+		PartitionKeys: []typedef.PartitionKeys{
+			{Values: typedef.NewValuesFromMap(map[string][]any{"pk": {1}})},
+		},
+		Query: "INSERT INTO ks.t(pk) VALUES (?)",
+	}
+
+	err := ds.Mutate(t.Context(), stmt)
+	require.Error(t, err, "a half-successful compensation must not be reported as success")
+
+	var mutErr *MutationError
+	require.ErrorAs(t, err, &mutErr)
+
+	// The precondition that makes this bug invisible: the flags agree.
+	require.Equal(t, mutErr.TestStoreSuccess, mutErr.OracleStoreSuccess,
+		"precondition: both original writes timed out, so the flags look symmetric")
+
+	assert.True(t, mutErr.CompensationFailed,
+		"partial compensation must be signalled explicitly; the success flags cannot express it")
+}
+
+func TestDelegatingStore_Mutate_AsymmetricCommit_IncrementsMetric(t *testing.T) {
+	t.Parallel()
+	// Unique store names so this test owns its own label vector element and
+	// does not race the global counter against other parallel tests.
+	const testName, oracleName = "test-asym-uncomp", "oracle-asym-uncomp"
+
+	counter := metrics.MutationAsymmetricAcksTotal.WithLabelValues("uncompensated", testName)
+	before := testutil.ToFloat64(counter)
+
+	// Test commits on the first attempt; oracle fails every attempt with a
+	// non-timeout error, so compensation does not apply and the divergence is
+	// surfaced as an uncompensated asymmetric commit on the test cluster.
+	test := &fakeStore{nameStr: testName, mutateSeq: []error{nil, nil}}
+	oracle := &fakeStore{nameStr: oracleName, mutateSeq: []error{errors.New("oracle-fail"), errors.New("oracle-fail")}}
+
+	ds := &delegatingStore{
+		inflight:             new(sync.WaitGroup),
+		testStore:            test,
+		oracleStore:          oracle,
+		mutationRetries:      1, // two attempts total
+		mutationRetrySleep:   1 * time.Millisecond,
+		minimumDelay:         1 * time.Millisecond,
+		serverSideTimestamps: true,
+	}
+
+	stmt := typedef.SimpleStmt("UPDATE ks.t SET v=1 WHERE k=1", typedef.UpdateStatementType)
+	err := ds.Mutate(t.Context(), stmt)
+	require.Error(t, err)
+
+	assert.Equal(t, before+1, testutil.ToFloat64(counter),
+		"asymmetric commit (test committed, oracle failed) must increment the divergence counter")
 }
 
 func TestDelegatingStore_Mutate_ContextCanceledDuringBackoff_ReturnsNil(t *testing.T) {

--- a/pkg/store/errors.go
+++ b/pkg/store/errors.go
@@ -136,6 +136,23 @@ type MutationError struct {
 	ValidationError         // Embed ValidationError for common functionality
 	TestStoreSuccess   bool `json:"test_store_success"`
 	OracleStoreSuccess bool `json:"oracle_store_success"`
+
+	// CompensationFailed reports that a compensating whole-partition DELETE was
+	// attempted after a timeout and did NOT fully succeed on both clusters.
+	//
+	// This is a separate signal from the two success flags above, and the
+	// difference is load-bearing. Those flags describe the ORIGINAL write; when
+	// both clusters time out they are equal (both false) even though each server
+	// may independently have committed or not. Compensation exists precisely to
+	// collapse that ambiguity by deleting the partition on both sides. If it only
+	// half-succeeds, the clusters can be left genuinely different — one erased,
+	// one still holding a write that timed out but committed — while the original
+	// flags still look symmetric.
+	//
+	// Callers must therefore treat this as an explicit requirement to invalidate
+	// the affected partitions: without it, a partial compensation failure silently
+	// manufactures a divergence that validation later reports as a product bug.
+	CompensationFailed bool `json:"compensation_failed"`
 }
 
 // NewStoreMutationError creates a new StoreMutationError

--- a/pkg/store/mocks_test.go
+++ b/pkg/store/mocks_test.go
@@ -27,6 +27,7 @@ import (
 // mockStoreLoader is a mock implementation of storeLoader interface
 type mockStoreLoader struct {
 	mock.Mock
+	nameStr string
 }
 
 func (m *mockStoreLoader) Init() error {
@@ -54,6 +55,5 @@ func (m *mockStoreLoader) Close() error {
 }
 
 func (m *mockStoreLoader) name() string {
-	args := m.Called()
-	return args.String(0)
+	return m.nameStr
 }

--- a/pkg/store/new_close_test.go
+++ b/pkg/store/new_close_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build testing
+
 package store
 
 import (

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/scylladb/gemini/pkg/joberror"
+	"github.com/scylladb/gemini/pkg/metrics"
 	"github.com/scylladb/gemini/pkg/replication"
 	"github.com/scylladb/gemini/pkg/stmtlogger"
 	"github.com/scylladb/gemini/pkg/stmtlogger/scylla"
@@ -314,7 +315,17 @@ func (ds delegatingStore) buildPartitionDeleteStmt(keys *typedef.PartitionKeys, 
 // ensure the process exits promptly (e.g. via the watchdog).
 // Errors are logged but not returned; this is a best-effort operation.
 // Returns true if all deletes completed without error.
-func (ds delegatingStore) compensateAsymmetricWrite(stmt *typedef.Stmt) bool {
+//
+// The caller's write timestamp (ts) is threaded through so the compensating
+// DELETE lands in the SAME timestamp domain as the original writes. This is
+// load-bearing when client-side timestamps are in use (the default): both
+// clusters then apply the tombstone at one identical absolute timestamp, so the
+// cutoff is the same on both sides. Using a server-side timestamp here (as this
+// function did previously) makes each coordinator stamp the delete with its own
+// clock, so a later write can fall on opposite sides of the two clusters' delete
+// timestamps under clock skew — reintroducing the very divergence this is meant
+// to erase.
+func (ds delegatingStore) compensateAsymmetricWrite(stmt *typedef.Stmt, ts mo.Option[time.Time]) bool {
 	if len(stmt.PartitionKeys) == 0 || len(ds.partitionKeyColumns) == 0 {
 		return true
 	}
@@ -329,7 +340,6 @@ func (ds delegatingStore) compensateAsymmetricWrite(stmt *typedef.Stmt) bool {
 	compCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	ts := mo.None[time.Time]()
 	ok := true
 
 	for i := range stmt.PartitionKeys {
@@ -338,18 +348,42 @@ func (ds delegatingStore) compensateAsymmetricWrite(stmt *typedef.Stmt) bool {
 			continue
 		}
 
-		if err := ds.testStore.mutate(compCtx, deleteStmt, ts); err != nil {
+		// Attach ContextData so the gocql observers record these compensating
+		// deletes in the statement log. Without it MustGetContextData returns nil
+		// and the observers skip logging entirely, making compensation invisible
+		// during post-mortem triage even though the deletes still execute.
+		//
+		// CompensationAttempt tags the entry so triage can tell a compensating
+		// delete apart from ordinary workload hitting the same partition.
+		//
+		// Note that logging is not free here: routing these deletes through the
+		// observers hands them to the statement logger's channel, which blocks on
+		// back-pressure and takes no context. The 15s compCtx bounds the CQL
+		// round-trips, not the log enqueue, so it is no longer a hard ceiling on
+		// this loop — and the mass-timeout conditions that trigger compensation
+		// are exactly when the logger is most likely to be backed up.
+		delCtx := WithContextData(compCtx, &ContextData{
+			Statement:     deleteStmt,
+			GeminiAttempt: CompensationAttempt,
+			Timestamp:     time.Now().UTC(),
+		})
+
+		if err := ds.testStore.mutate(delCtx, deleteStmt, ts); err != nil {
 			ds.getLogger().Error("compensating delete on test store failed — partition may be asymmetric",
 				zap.String("partition", stmt.PartitionKeys[i].ID.String()),
 				zap.Error(err))
+			metrics.MutationCompensationFailuresTotal.WithLabelValues(ds.testStore.name()).Inc()
+
 			ok = false
 		}
 
 		if ds.oracleStore != nil {
-			if err := ds.oracleStore.mutate(compCtx, deleteStmt, ts); err != nil {
+			if err := ds.oracleStore.mutate(delCtx, deleteStmt, ts); err != nil {
 				ds.getLogger().Error("compensating delete on oracle store failed — partition may be asymmetric",
 					zap.String("partition", stmt.PartitionKeys[i].ID.String()),
 					zap.Error(err))
+				metrics.MutationCompensationFailuresTotal.WithLabelValues(ds.oracleStore.name()).Inc()
+
 				ok = false
 			}
 		}
@@ -373,6 +407,40 @@ func isOnlyTimeoutFailure(result mutationResult) bool {
 	oracleTimeout := result.oracleErr == nil || errors.Is(result.oracleErr, context.DeadlineExceeded)
 	atLeastOne := errors.Is(result.testErr, context.DeadlineExceeded) || errors.Is(result.oracleErr, context.DeadlineExceeded)
 	return testTimeout && oracleTimeout && atLeastOne
+}
+
+// recordAsymmetricAck counts a dual-write that exactly one cluster
+// acknowledged. Derived from gemini's own per-store bookkeeping rather than the
+// statement log, so the signal survives a stalled or lossy logger.
+//
+// It deliberately records ACKNOWLEDGEMENT asymmetry, not confirmed divergence.
+// A nil error proves the server acknowledged the write; a non-nil error does
+// NOT prove the write was not applied, because a timed-out server may have
+// committed and merely lost the response. Labelling that as a confirmed
+// one-sided commit would emit a false corruption signal, which is the failure
+// mode this whole change set exists to avoid — so the metric says only what is
+// observable: one side answered, the other did not.
+//
+// Symmetric results (both acknowledged, or neither) are not counted;
+// single-cluster runs (no oracle) are skipped entirely.
+func (ds delegatingStore) recordAsymmetricAck(result mutationResult, outcome string) {
+	if ds.oracleStore == nil {
+		return
+	}
+
+	testAcked := result.testDone && result.testErr == nil
+	oracleAcked := result.oracleDone && result.oracleErr == nil
+
+	if testAcked == oracleAcked {
+		return
+	}
+
+	ackedStore := ds.oracleStore.name()
+	if testAcked {
+		ackedStore = ds.testStore.name()
+	}
+
+	metrics.MutationAsymmetricAcksTotal.WithLabelValues(outcome, ackedStore).Inc()
 }
 
 func (ds delegatingStore) Create(ctx context.Context, testBuilder, stmt *typedef.Stmt) error {
@@ -690,14 +758,24 @@ func (ds delegatingStore) Mutate(ctx context.Context, stmt *typedef.Stmt) error 
 				// DELETE on both stores so the partition is deterministically
 				// empty for the upcoming validation phase.  On success, return
 				// nil so the partition is NOT marked invalid.
-				if isOnlyTimeoutFailure(cumulativeResult) && ds.compensateAsymmetricWrite(stmt) {
-					return nil
+				if isOnlyTimeoutFailure(cumulativeResult) {
+					if ds.compensateAsymmetricWrite(stmt, ts) {
+						ds.recordAsymmetricAck(cumulativeResult, "compensated")
+						return nil
+					}
+					// Compensation ran but did not fully succeed, so the partition's
+					// cross-cluster state is now unknown even if the ORIGINAL writes
+					// failed symmetrically. Flag it explicitly: the success flags
+					// alone would look symmetric and mutation.run() would leave the
+					// partition valid, silently manufacturing a divergence.
+					mutationErr.CompensationFailed = true
 				}
 
 				// Compensation not applicable or failed — return the
-				// MutationError so mutation.run() can inspect
-				// TestStoreSuccess / OracleStoreSuccess and mark the affected
-				// partitions invalid, preventing a false divergence report.
+				// MutationError so mutation.run() can mark the affected partitions
+				// invalid, preventing a false divergence report.
+				ds.recordAsymmetricAck(cumulativeResult, "uncompensated")
+
 				return mutationErr
 			}
 		}
@@ -722,9 +800,18 @@ func (ds delegatingStore) Mutate(ctx context.Context, stmt *typedef.Stmt) error 
 	// on both stores so the partition is deterministically empty before the
 	// validation phase starts.  On success return nil so the partition is not
 	// marked invalid.
-	if isOnlyTimeoutFailure(cumulativeResult) && ds.compensateAsymmetricWrite(stmt) {
-		return nil
+	if isOnlyTimeoutFailure(cumulativeResult) {
+		if ds.compensateAsymmetricWrite(stmt, ts) {
+			ds.recordAsymmetricAck(cumulativeResult, "compensated")
+			return nil
+		}
+		// See the retry-loop site above: a partial compensation failure leaves the
+		// clusters in an unknown state that the symmetric success flags cannot
+		// express, so it must be signalled explicitly.
+		mutationErr.CompensationFailed = true
 	}
+
+	ds.recordAsymmetricAck(cumulativeResult, "uncompensated")
 
 	ds.getLogger().Error("mutation failed after all retry attempts",
 		zap.Int("total_attempts", maxAttempts),


### PR DESCRIPTION
## Summary

Fixes surfaced while investigating Argus run `3efc775f` (silent `missing_in_oracle` divergence under nemesis), plus a divergence-observability gap raised by a companion report. None of these is proven to be *that* run's root cause (see caveat) — they are real latent bugs and triage-trust gaps found along the way.

### `fix(store)`: harden asymmetric-write compensation
`compensateAsymmetricWrite` had two latent bugs:
- It stamped its compensating delete with a **server-side** timestamp while normal writes use **client-side**. Under clock skew, the delete and a later write could land on opposite sides of the two coordinators' cutoffs and *reintroduce* divergence. Now threads the caller's write timestamp through. (Reusing the *same* timestamp as the original write is deliberate: Cassandra/Scylla cell reconciliation breaks equal-timestamp ties in favour of a tombstone, so the delete deterministically erases the write on whichever cluster committed it.)
- It ran on a `ContextData`-less context, so the gocql observers skipped logging it — compensation was invisible in `_logs`. Now attaches `ContextData` per delete, tagged with the `CompensationAttempt` (-1) sentinel so triage can tell a compensating delete apart from ordinary workload against the same partition. Attempt counters are zero-based, so a negative value cannot collide.

> Note: attaching `ContextData` routes these deletes through the statement logger's channel, which blocks on back-pressure and takes no context. The 15s `compCtx` bounds the CQL round-trips, not the log enqueue, so it is no longer a hard ceiling on that loop — and mass-timeout conditions that trigger compensation are exactly when the logger is most likely backed up. Every other mutation path already accepts this same back-pressure.

### Divergence alarm: surface asymmetric dual-write acknowledgements
A companion report claimed the statement logger silently drops ~11% of dual-write mutations on one cluster only. The orphan counts reproduce under a strict join, but the dual-write-gap reading does not hold up: the orphans are symmetric (91 test-only vs 89 oracle-only), all carry `error=""` and `gemini_attempt=0`, are tail-biased, and — decisively — the 89 oracle-only orphans produce **zero** `missing_in_test` corruptions. They are log-completeness artifacts, not lost writes.

The report's suggested fix (gate mutation completion on matched entries in *both* statement logs) is not implemented, deliberately: it would re-couple the hot write path to a lossy, back-pressuring subsystem with a prior OOM history, and gate correctness on the very signal that is dropping entries.

What *was* missing is observability on the signal gemini already computes for itself. Asymmetric outcomes were already handled (compensated, or partitions marked invalid) but were nearly invisible — a Debug log and no metric, i.e. exactly the "silently accumulate" the report complains about. This adds `gemini_mutation_asymmetric_acks_total{outcome,acked_store}`, derived from gemini's own per-store bookkeeping (`MutationError.TestStoreSuccess` vs `OracleStoreSuccess`), and raises the asymmetric-write log from Debug to Warn. The metric counts **acknowledgements, not confirmed commits**: a non-nil error proves a store did not acknowledge, but does not prove the write was never applied — a timed-out server may have committed and lost the response. Reporting that as confirmed divergence would emit exactly the false corruption signal this PR exists to avoid, so the metric name, labels, log message and docs all say "may have diverged". Divergence is now alertable in Prometheus/Argus at write time instead of surfacing hours later as an unrelated-looking validation mismatch.

### `fix(statements)`: renormalize mutation-type ratios, and reject impossible filters
`GetMutationStatementType` walked the cumulative distribution and skipped filtered types **without renormalizing**, so the filtered mass (deletes, during warmup) fell through to the `insert` fallback instead of being redistributed. With `InsertRatio=0` this fabricated inserts and starved updates. Now reconstructs per-type weights, sums the non-filtered mass, and samples within it.

The no-candidate case is now explicit rather than falling back to `StatementTypeInsert` — which returned a type the caller had **explicitly excluded**, fabricating the exact disallowed statement the filter exists to prevent. The method returns `(StatementType, error)` and reports `ErrNoMutationCandidates`. Both fallback paths are fixed: the zero-total case, and the floating-point tail, which now falls back to the last *surviving* candidate. Zero-weight types are skipped during the walk.

The error is terminal in the mutation worker: `Mutation.Do` continues on unrecognised errors, and this condition is permanent (ratios and filter are both fixed for the run), so falling through would hot-spin the worker forever with no output. It now logs at Error, sets the soft stop flag, and returns.

⚠️ **Baseline impact:** the redistribution fix changes the default warmup insert:update mix for **every existing deployment** (≈0.75/0.25 → ≈0.737/0.263), not just the synthetic 0.2/0.3/0.5 example above. This is correct and intended, but it will move Argus baselines — a diff there after this merges is expected, not a regression.

### `test(stmtlogger)`: guard statement/values pairing
A full pin-down of the logger pipeline found the statement/values pairing **coherent on every path** (observer clones at observe time; parallel dual-send shares `stmt` read-only; no `*typedef.Stmt` pooling; committer uses per-index buffers; single-insert execs synchronously before pool return). The earlier "logger mispairs under concurrency" hypothesis does **not** survive code review — retracted.

`fillArgs` buffer reuse (`held[idx]`) had **no covering test**, though. Added two `-race` regression tests asserting every bound row's partition-key, statement, and values columns come from the same item — under sequential buffer reuse and concurrent binding through a shared `cqlStatements`. Assertions run on the parent goroutine (workers report failures over a channel) since `require`/`t.FailNow` are only legal on the test goroutine; a start barrier releases all 16 workers together so the concurrent path is genuinely exercised.

### `fix(test)`: unbreak `go vet ./...`
`pkg/testutils` declares `ScyllaContainer` twice — under `//go:build !testing` without port accessors, and under `//go:build testing` with `TestPort`/`OraclePort`. `workload_test.go` and `new_close_test.go` used the tagged symbols but carried no build tag, so an untagged `go vet ./...` compiled them against the stub and failed. Every other `testutils` consumer already had the tag; these two were the outliers. Pre-existing on master, not introduced here.

## Caveat
The validation-confirmed `missing_in_oracle` divergence is real, but its cause is **not** provable from these changes. If a live `_logs` mispair exists, it most likely originates in the gocql driver's `ObservedQuery`, out of reach from this repo — the only conclusive check is a Scylla-backed integration test that round-trips real dual-writes.

## Testing
- `go test -tags testing -race ./pkg/store/... ./pkg/statements/... ./pkg/jobs/... ./pkg/stmtlogger/...` — pass
- `go vet ./...` and `go vet -tags testing ./...` — both clean (the former was broken before this branch)
- `golangci-lint run ./...` — 0 issues
- The `ErrNoMutationCandidates` terminal branch is covered by a test verified in both directions: it passes as written, and fails with `"Mutation.Do did not return: it is spinning"` when the branch is sabotaged
- New docs: `docs/metrics.md` (metric labels, the acknowledgement-vs-commit caveat, example alerts) and `docs/statement-ratio.md` (renormalization worked example, baseline shift, no-valid-candidate configs)

Refs: https://scylladb.atlassian.net/browse/QATOOLS-318

<!-- Intentionally `Refs:` rather than `Closes:` — the root cause of run 3efc775f
     is still open (see Caveat). These changes harden adjacent latent bugs and add
     the missing divergence alarm; none is proven to be that run's cause, so the
     ticket should not auto-close on merge. -->
