### PR TITLE
ci(renovate): stop Renovate from proposing gocql v2

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,8 @@
         "gomod"
       ],
       "matchPackageNames": [
-        "!github.com/scylladb/gocql"
+        "!github.com/scylladb/gocql",
+        "!github.com/gocql/gocql"
       ],
       "addLabels": [
         "test/integration"
@@ -55,6 +56,13 @@
         "test/integration"
       ],
       "enabled": true
+    },
+    {
+      "description": "Replaced by github.com/scylladb/gocql via the go.mod replace directive",
+      "matchPackageNames": [
+        "github.com/gocql/gocql"
+      ],
+      "enabled": false
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Problem

`go.mod` replaces `github.com/gocql/gocql` with `github.com/scylladb/gocql`:

```
replace github.com/gocql/gocql => github.com/scylladb/gocql v1.18.3
```

Renovate does not know about the replace directive. It sees the upstream module and proposes `v1.8.0 -> v2.1.2`. Upstream v2 is not the Scylla fork, so the bump is invalid for this repository.

## Change

- Disable the `github.com/gocql/gocql` package in Renovate.
- Exclude it from the "All other Go dependencies" group.

The disable rule is the last entry in `packageRules`. Renovate applies the rules in order and the last match wins. A rule that only holds negative matchers, such as `!github.com/scylladb/gocql`, matches every other package. It matches `github.com/gocql/gocql` too and would re-enable it if it came after the disable rule.

`github.com/scylladb/gocql` keeps its own rule and continues to get separate update PRs.

Same intent as scylla-bench [#bd20dca](https://github.com/scylladb/scylla-bench/commit/bd20dca), with the rule order corrected.