### PR TITLE
fix: restore DC-agnostic replication and fail-fast JSON insert conversion

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -312,10 +312,10 @@ func printSetup(schema *typedef.Schema, ratio statements.Ratios, seed, schemaSee
 	}
 	_ = tw.Flush()
 
-	jsonSchema := utils.MarshalJSONIndent(schema, "", "    ")
+	jsonSchema := utils.MarshalJSONIndentUnchecked(schema, "", "    ")
 	fmt.Printf("Schema: %v\n", string(jsonSchema))
 
-	jsonStatementsRatio := utils.MarshalJSONIndent(ratio, "", "    ")
+	jsonStatementsRatio := utils.MarshalJSONIndentUnchecked(ratio, "", "    ")
 	fmt.Printf("Statement Ratios: %v\n", string(jsonStatementsRatio))
 }
 

--- a/pkg/joberror/joberror.go
+++ b/pkg/joberror/joberror.go
@@ -72,7 +72,7 @@ type JobError struct {
 }
 
 func (j *JobError) Error() string {
-	data := utils.MarshalJSON(j.PartitionKeys)
+	data := utils.MarshalJSONUnchecked(j.PartitionKeys)
 
 	return fmt.Sprintf(
 		"JobError(err=%v): %s (stmt-type=%s, query=%s, time=%s) partition-keys=%s",
@@ -101,7 +101,7 @@ func (j *JobError) Hash() [32]byte {
 
 		for _, key := range keys {
 			hasher.Write(utils.UnsafeBytes(key))
-			data := utils.MarshalJSON(j.PartitionKeys.Get(key))
+			data := utils.MarshalJSONUnchecked(j.PartitionKeys.Get(key))
 			hasher.Write(data)
 		}
 	}
@@ -197,7 +197,7 @@ func (el *ListError) Close() error {
 	return nil
 }
 
-func NewErrorList(limit int) *ListError {
+func NewListError(limit int) *ListError {
 	return &ListError{
 		limit:  limit,
 		errors: make([]JobError, 0, limit),

--- a/pkg/joberror/joberror_test.go
+++ b/pkg/joberror/joberror_test.go
@@ -65,14 +65,14 @@ func TestJobError_ErrorWithEmptyFields(t *testing.T) {
 	require.NotEmpty(t, actual)
 }
 
-func TestNewErrorList(t *testing.T) {
+func TestNewListError(t *testing.T) {
 	t.Parallel()
 
 	limit := 5
-	el := NewErrorList(limit)
+	el := NewListError(limit)
 
 	if el == nil {
-		t.Fatal("NewErrorList returned nil")
+		t.Fatal("NewListError returned nil")
 	}
 
 	if el.limit != limit {
@@ -149,7 +149,7 @@ func TestHashHex_StableAndMatchesSum(t *testing.T) {
 func TestErrorList_AddError(t *testing.T) {
 	t.Parallel()
 
-	el := NewErrorList(3)
+	el := NewListError(3)
 	timestamp := time.Now()
 
 	err1 := JobError{
@@ -188,7 +188,7 @@ func TestErrorList_AddError(t *testing.T) {
 func TestErrorList_AddErrorExceedsLimit(t *testing.T) {
 	t.Parallel()
 
-	el := NewErrorList(2)
+	el := NewListError(2)
 	timestamp := time.Now()
 
 	// Add exactly limit number of errors
@@ -237,7 +237,7 @@ func TestErrorList_AddErrorExceedsLimit(t *testing.T) {
 func TestErrorList_Errors(t *testing.T) {
 	t.Parallel()
 
-	el := NewErrorList(5)
+	el := NewListError(5)
 	timestamp := time.Now()
 
 	// Test empty list
@@ -268,7 +268,7 @@ func TestErrorList_Error(t *testing.T) {
 	t.Parallel()
 
 	assert := require.New(t)
-	el := NewErrorList(3)
+	el := NewListError(3)
 	timestamp := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
 
 	assert.Empty(el.Error())
@@ -298,7 +298,7 @@ func TestErrorList_Error(t *testing.T) {
 }
 
 func TestErrorList_ConcurrentAccess(t *testing.T) {
-	el := NewErrorList(100)
+	el := NewListError(100)
 	timestamp := time.Now()
 
 	var wg sync.WaitGroup

--- a/pkg/joberror/summary.go
+++ b/pkg/joberror/summary.go
@@ -309,7 +309,7 @@ func buildStmtKeyFromValues(v partitionKeyReader) string {
 				val = json.Number(strconv.FormatInt(i64, 10))
 			}
 		}
-		b := utils.MarshalJSON(val)
+		b := utils.MarshalJSONUnchecked(val)
 		sb.Write(b)
 	}
 	return sb.String()

--- a/pkg/jobs/validation.go
+++ b/pkg/jobs/validation.go
@@ -373,8 +373,8 @@ func marshalDifferentRows(diffs []store.RowDifference) []joberror.RowDiff {
 	}
 	result := make([]joberror.RowDiff, 0, len(diffs))
 	for _, d := range diffs {
-		testData := utils.MarshalJSON(d.TestRow)
-		oracleData := utils.MarshalJSON(d.OracleRow)
+		testData := utils.MarshalJSONUnchecked(d.TestRow)
+		oracleData := utils.MarshalJSONUnchecked(d.OracleRow)
 		result = append(result, joberror.RowDiff{
 			TestRow:   testData,
 			OracleRow: oracleData,

--- a/pkg/replication/replication.go
+++ b/pkg/replication/replication.go
@@ -24,7 +24,7 @@ import (
 type Replication map[string]any
 
 func (r Replication) ToCQL() string {
-	b := utils.MarshalJSON(r)
+	b := utils.MarshalJSONUnchecked(r)
 	return strings.ReplaceAll(string(b), "\"", "'")
 }
 
@@ -38,7 +38,6 @@ func NewSimpleStrategy() Replication {
 func NewNetworkTopologyStrategy() Replication {
 	return Replication{
 		"class":              "NetworkTopologyStrategy",
-		"datacenter1":        1,
 		"replication_factor": 1,
 	}
 }

--- a/pkg/replication/replication_test.go
+++ b/pkg/replication/replication_test.go
@@ -41,7 +41,6 @@ func TestMarshalJSON(t *testing.T) {
 			r: replication.NewNetworkTopologyStrategy(),
 			want: map[string]any{
 				"class":              "NetworkTopologyStrategy",
-				"datacenter1":        float64(1),
 				"replication_factor": float64(1),
 			},
 		},
@@ -171,7 +170,7 @@ func TestToCQL(t *testing.T) {
 		},
 		"network": {
 			rs:   replication.NewNetworkTopologyStrategy(),
-			want: "{'class':'NetworkTopologyStrategy','datacenter1':1,'replication_factor':1}",
+			want: "{'class':'NetworkTopologyStrategy','replication_factor':1}",
 		},
 	}
 	for name := range tests {

--- a/pkg/statements/insert.go
+++ b/pkg/statements/insert.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -84,10 +85,19 @@ func (g *Generator) InsertJSON(_ context.Context) (*typedef.Stmt, error) {
 		case typedef.SimpleType:
 			values[pk.Name] = convertForJSON(t, pks.Values.Get(pk.Name)[0])
 		case *typedef.TupleType:
-			tupVals := make([]any, 0, len(t.ValueTypes))
-			for _, value := range t.ValueTypes {
-				tupVals = append(tupVals, convertForJSON(t, value))
+			elems := pks.Values.Get(pk.Name)
+			if len(elems) != len(t.ValueTypes) {
+				return nil, fmt.Errorf(
+					"partition key %q carries %d values, want %d for %s",
+					pk.Name, len(elems), len(t.ValueTypes), t.CQLDef(),
+				)
 			}
+
+			tupVals := make([]any, len(t.ValueTypes))
+			for i, elemType := range t.ValueTypes {
+				tupVals[i] = convertForJSON(elemType, elems[i])
+			}
+
 			values[pk.Name] = tupVals
 		default:
 			panic("unknown type: " + t.Name())
@@ -114,7 +124,7 @@ func (g *Generator) InsertJSON(_ context.Context) (*typedef.Stmt, error) {
 func convertForJSON(vType typedef.Type, value any) any {
 	switch vType {
 	case typedef.TypeBlob:
-		val, _ := value.([]byte)
+		val := mustConvert[[]byte](vType, value)
 		buffer := bytes.NewBuffer(nil)
 		buffer.Grow(len(val)*2 + 2) // 2 for "0x" prefix
 		buffer.WriteString("0x")
@@ -122,29 +132,29 @@ func convertForJSON(vType typedef.Type, value any) any {
 		_, _ = encoder.Write(val)
 		return utils.UnsafeString(buffer.Bytes())
 	case typedef.TypeDate:
-		if val, ok := value.(time.Time); ok {
-			return val.Format(time.DateOnly)
-		}
+		return mustConvert[time.Time](vType, value).Format(time.DateOnly)
 	case typedef.TypeDuration:
-		if val, ok := value.(time.Duration); ok {
-			return utils.TimeDurationToScyllaDuration(val)
-		}
+		return utils.TimeDurationToScyllaDuration(mustConvert[time.Duration](vType, value))
 	case typedef.TypeDecimal:
-		if val, ok := value.(*inf.Dec); ok {
-			return val.String()
-		}
+		return mustConvert[*inf.Dec](vType, value).String()
 	case typedef.TypeUUID, typedef.TypeTimeuuid:
-		if val, ok := value.(gocql.UUID); ok {
-			return val.String()
-		}
+		return mustConvert[gocql.UUID](vType, value).String()
 	case typedef.TypeVarint:
-		if val, ok := value.(*big.Int); ok {
-			return val.String()
-		}
+		return mustConvert[*big.Int](vType, value).String()
 	case typedef.TypeTime:
-		val, _ := value.(int64)
-		return time.Unix(0, val).UTC().Format("15:04:05.000000000")
+		val := mustConvert[time.Duration](vType, value)
+		return time.Unix(0, int64(val)).UTC().Format("15:04:05.000000000")
 	}
 
 	return value
+}
+
+func mustConvert[T any](vType typedef.Type, value any) T {
+	val, ok := value.(T)
+	if !ok {
+		var want T
+		panic(fmt.Sprintf("gemini generated %T for column type %s, want %T", value, vType.CQLDef(), want))
+	}
+
+	return val
 }

--- a/pkg/statements/select_test.go
+++ b/pkg/statements/select_test.go
@@ -17,16 +17,124 @@ package statements
 import (
 	"bytes"
 	"encoding/hex"
+	"encoding/json"
 	"math/big"
+	"math/rand/v2"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/gocql/gocql"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/inf.v0"
 
 	"github.com/scylladb/gemini/pkg/typedef"
+	"github.com/scylladb/gemini/pkg/utils"
 )
+
+func TestConvertForJSON_EveryPartitionKeyTypeKeepsItsValue(t *testing.T) {
+	t.Parallel()
+
+	utils.PreallocateRandomString(rand.New(rand.NewChaCha8([32]byte{})), 1<<20)
+
+	valueRange := &typedef.ValueRangeConfig{
+		MaxBlobLength:   32,
+		MinBlobLength:   1,
+		MaxStringLength: 32,
+		MinStringLength: 1,
+	}
+
+	for _, pkType := range typedef.PartitionKeyTypes {
+		t.Run(pkType.Name(), func(t *testing.T) {
+			t.Parallel()
+
+			rng := rand.New(rand.NewChaCha8([32]byte{}))
+			encodings := make(map[string]struct{}, 32)
+
+			for range 32 {
+				generated := pkType.GenValue(rng, valueRange)
+				require.Len(t, generated, 1)
+
+				encoded, err := json.Marshal(convertForJSON(pkType, generated[0]))
+				require.NoError(t, err)
+				require.NotEqual(t, `"`+string(pkType)+`"`, string(encoded),
+					"conversion returned the CQL type name instead of the value")
+
+				encodings[string(encoded)] = struct{}{}
+			}
+
+			require.Greater(t, len(encodings), 1,
+				"every generated value encoded to the same JSON, so the conversion discards the value")
+		})
+	}
+}
+
+func TestInsertJSON_TuplePartitionKeyCarriesItsValues(t *testing.T) {
+	t.Parallel()
+
+	tupleType := &typedef.TupleType{
+		ComplexType: typedef.TypeTuple,
+		ValueTypes:  []typedef.SimpleType{typedef.TypeInt, typedef.TypeText, typedef.TypeUUID},
+	}
+
+	table := &typedef.Table{
+		Name:          "tuple_pk_table",
+		PartitionKeys: typedef.Columns{{Name: "pk1", Type: tupleType}},
+	}
+
+	wantUUID, err := gocql.RandomUUID()
+	require.NoError(t, err)
+
+	mp := newMockPartitions(1)
+	mp.nextKeys.Store(&typedef.PartitionKeys{
+		ID:     uuid.New(),
+		Values: typedef.NewValuesFromMap(map[string][]any{"pk1": {int32(7), "seven", wantUUID}}),
+	})
+
+	rng := rand.New(rand.NewChaCha8([32]byte{}))
+	rc, err := NewRatioController(DefaultStatementRatios(), rng)
+	require.NoError(t, err)
+
+	valueRange := &typedef.ValueRangeConfig{
+		MaxBlobLength:   32,
+		MinBlobLength:   1,
+		MaxStringLength: 32,
+		MinStringLength: 1,
+	}
+
+	gen := New("ks", mp, table, rng, valueRange, rc, false)
+
+	stmt, err := gen.InsertJSON(t.Context())
+	require.NoError(t, err)
+	require.Len(t, stmt.Values, 1)
+
+	payload, ok := stmt.Values[0].(string)
+	require.True(t, ok)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(payload), &decoded))
+
+	require.Equal(t, []any{float64(7), "seven", wantUUID.String()}, decoded["pk1"])
+}
+
+func TestConvertForJSON_GeneratedTimeKeepsItsValue(t *testing.T) {
+	t.Parallel()
+
+	generated := typedef.TypeTime.GenValue(rand.New(rand.NewPCG(1, 2)), typedef.ValueRangeConfig{})
+	for _, value := range generated {
+		result := convertForJSON(typedef.TypeTime, value)
+
+		str, ok := result.(string)
+		if !ok {
+			t.Fatalf("expected string, got %T", result)
+		}
+
+		if str == "00:00:00.000000000" {
+			t.Errorf("generated time collapsed to zero: %v (%T)", value, value)
+		}
+	}
+}
 
 func TestConvertForJSON(t *testing.T) {
 	t.Parallel()
@@ -132,14 +240,14 @@ func TestConvertForJSON(t *testing.T) {
 
 	t.Run("time", func(t *testing.T) {
 		t.Parallel()
-		ns := int64(12*3600+30*60+45)*1e9 + 123456789
-		result := convertForJSON(typedef.TypeTime, ns)
+		sinceMidnight := time.Duration(int64(12*3600+30*60+45)*1e9 + 123456789)
+		result := convertForJSON(typedef.TypeTime, sinceMidnight)
 		str, ok := result.(string)
 		if !ok {
 			t.Fatalf("expected string, got %T", result)
 		}
-		if str == "" {
-			t.Error("expected non-empty time string")
+		if want := "12:30:45.123456789"; str != want {
+			t.Errorf("got %q, want %q", str, want)
 		}
 	})
 

--- a/pkg/statements/statements_extra_test.go
+++ b/pkg/statements/statements_extra_test.go
@@ -34,6 +34,7 @@ import (
 // Do NOT add any field of type *rand.Rand or math/rand.Rand to this struct.
 type mockPartitions struct {
 	deleted      chan typedef.PartitionKeys
+	nextKeys     atomic.Pointer[typedef.PartitionKeys]
 	count        atomic.Uint64
 	invalidCount atomic.Uint64
 }
@@ -61,6 +62,10 @@ func (m *mockPartitions) Get(_ uint64) typedef.PartitionKeys {
 }
 
 func (m *mockPartitions) Next() typedef.PartitionKeys {
+	if keys := m.nextKeys.Load(); keys != nil {
+		return *keys
+	}
+
 	return typedef.PartitionKeys{ID: uuid.New()}
 }
 

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -149,7 +149,7 @@ func (gs *GlobalStatus) PrintResult(
 		for i, err := range gs.Errors.Errors() {
 			fmt.Printf("Error %d: %v\n", i, err)
 		}
-		jsonSchema := utils.MarshalJSONIndent(schema, "", "    ")
+		jsonSchema := utils.MarshalJSONIndentUnchecked(schema, "", "    ")
 		fmt.Printf("Schema: %v\n", string(jsonSchema))
 	}
 
@@ -170,6 +170,6 @@ func (gs *GlobalStatus) AddValidatedRows(rows int) {
 
 func NewGlobalStatus(limit int) *GlobalStatus {
 	return &GlobalStatus{
-		Errors: joberror.NewErrorList(limit),
+		Errors: joberror.NewListError(limit),
 	}
 }

--- a/pkg/stmtlogger/__snapshots__/scylla_test.snap
+++ b/pkg/stmtlogger/__snapshots__/scylla_test.snap
@@ -1,6 +1,6 @@
 
 [TestBuildQueriesCreation - 1]
-CREATE KEYSPACE IF NOT EXISTS ks1_logs WITH replication={'class':'NetworkTopologyStrategy','datacenter1':1,'replication_factor':1} AND durable_writes = true;
+CREATE KEYSPACE IF NOT EXISTS ks1_logs WITH replication={'class':'NetworkTopologyStrategy','replication_factor':1} AND durable_writes = true;
 createKeyspace
 ---
 

--- a/pkg/stmtlogger/scylla/cql_test.go
+++ b/pkg/stmtlogger/scylla/cql_test.go
@@ -46,7 +46,7 @@ func TestBuildCreateTableQuery(t *testing.T) {
 				},
 			},
 			replication:  replication.NewNetworkTopologyStrategy(),
-			wantKeyspace: "CREATE KEYSPACE IF NOT EXISTS test_logs WITH replication={'class':'NetworkTopologyStrategy','datacenter1':1,'replication_factor':1} AND durable_writes = true;",
+			wantKeyspace: "CREATE KEYSPACE IF NOT EXISTS test_logs WITH replication={'class':'NetworkTopologyStrategy','replication_factor':1} AND durable_writes = true;",
 			wantTable: "CREATE TABLE IF NOT EXISTS test_logs.test_statements(pk0 text," +
 				"ts bigint, seq bigint, ty text, statement text, values frozen<list<text>>, host text, attempt smallint, " +
 				"gemini_attempt smallint, error text, dur duration, PRIMARY KEY ((pk0, ty), ts, attempt, gemini_attempt, seq)) " +
@@ -68,7 +68,7 @@ func TestBuildCreateTableQuery(t *testing.T) {
 				},
 			},
 			replication:  replication.NewNetworkTopologyStrategy(),
-			wantKeyspace: "CREATE KEYSPACE IF NOT EXISTS test_logs WITH replication={'class':'NetworkTopologyStrategy','datacenter1':1,'replication_factor':1} AND durable_writes = true;",
+			wantKeyspace: "CREATE KEYSPACE IF NOT EXISTS test_logs WITH replication={'class':'NetworkTopologyStrategy','replication_factor':1} AND durable_writes = true;",
 			wantTable: "CREATE TABLE IF NOT EXISTS test_logs.test_statements(pk0 text,pk1 int," +
 				"ts bigint, seq bigint, ty text, statement text, values frozen<list<text>>, host text, attempt smallint, " +
 				"gemini_attempt smallint, error text, dur duration, PRIMARY KEY ((pk0,pk1, ty), ts, attempt, gemini_attempt, seq)) " +
@@ -86,7 +86,7 @@ func TestBuildCreateTableQuery(t *testing.T) {
 				},
 			},
 			replication:  replication.NewNetworkTopologyStrategy(),
-			wantKeyspace: "CREATE KEYSPACE IF NOT EXISTS ks_logs WITH replication={'class':'NetworkTopologyStrategy','datacenter1':1,'replication_factor':1} AND durable_writes = true;",
+			wantKeyspace: "CREATE KEYSPACE IF NOT EXISTS ks_logs WITH replication={'class':'NetworkTopologyStrategy','replication_factor':1} AND durable_writes = true;",
 			wantTable: "CREATE TABLE IF NOT EXISTS ks_logs.tbl_statements(id uuid," +
 				"ts bigint, seq bigint, ty text, statement text, values frozen<list<text>>, host text, attempt smallint, " +
 				"gemini_attempt smallint, error text, dur duration, PRIMARY KEY ((id, ty), ts, attempt, gemini_attempt, seq)) " +

--- a/pkg/stmtlogger/scylla/joberror_metrics.go
+++ b/pkg/stmtlogger/scylla/joberror_metrics.go
@@ -85,11 +85,11 @@ func partitionHashFromValues(v *typedef.Values) string {
 			b.WriteByte(',')
 		}
 		// Marshal key
-		kb := utils.MarshalJSON(k)
+		kb := utils.MarshalJSONUnchecked(k)
 		b.Write(kb)
 		b.WriteByte(':')
 		// Marshal values
-		vb := utils.MarshalJSON(m[k])
+		vb := utils.MarshalJSONUnchecked(m[k])
 		b.Write(vb)
 	}
 	b.WriteByte('}')

--- a/pkg/stmtlogger/scylla/scylla.go
+++ b/pkg/stmtlogger/scylla/scylla.go
@@ -77,8 +77,11 @@ type (
 		fetchCancel context.CancelFunc
 		fetchHook   func(ctx context.Context, ty stmtlogger.Type, jobError *joberror.JobError, w io.Writer) (int64, error)
 		// openHook is openStatementFile outside tests.
-		openHook func(name string) (*bufio.Writer, func() error, error)
-		wg       sync.WaitGroup
+		openHook      func(name string) (*bufio.Writer, func() error, error)
+		makeBatchHook func(ctx context.Context) *gocql.Batch
+		execBatchHook func(ctx context.Context, batch *gocql.Batch) error
+		execQueryHook func(ctx context.Context, stmt string, args ...any) error
+		wg            sync.WaitGroup
 		// fetchDelay is statementErrorFetchDelay outside tests.
 		fetchDelay        time.Duration
 		malformedWarnOnce sync.Once
@@ -478,16 +481,28 @@ func (s *Logger) bind(it stmtlogger.Item, dst []any) (*cqlStatements, []any, boo
 
 // makeBatch creates a new gocql batch on the shared _logs session.
 func (s *Logger) makeBatch(ctx context.Context) *gocql.Batch {
+	if s.makeBatchHook != nil {
+		return s.makeBatchHook(ctx)
+	}
+
 	return s.session.BatchWithContext(ctx, gocql.UnloggedBatch)
 }
 
 // execBatch executes the provided batch on the shared _logs session.
-func (s *Logger) execBatch(_ context.Context, batch *gocql.Batch) error {
+func (s *Logger) execBatch(ctx context.Context, batch *gocql.Batch) error {
+	if s.execBatchHook != nil {
+		return s.execBatchHook(ctx, batch)
+	}
+
 	return s.session.ExecuteBatch(batch)
 }
 
 // execQuery executes a single statement on the shared _logs session.
 func (s *Logger) execQuery(ctx context.Context, stmt string, args ...any) error {
+	if s.execQueryHook != nil {
+		return s.execQueryHook(ctx, stmt, args...)
+	}
+
 	q := s.session.QueryWithContext(ctx, stmt, args...)
 	defer q.Release()
 	return q.Exec()

--- a/pkg/stmtlogger/scylla/scylla_pairing_test.go
+++ b/pkg/stmtlogger/scylla/scylla_pairing_test.go
@@ -15,14 +15,19 @@
 package scylla
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/gocql/gocql"
 	"github.com/samber/mo"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/scylladb/gemini/pkg/stmtlogger"
 	"github.com/scylladb/gemini/pkg/typedef"
@@ -158,4 +163,235 @@ func TestFillArgs_ConcurrentBindingIsCoherent(t *testing.T) {
 	for err := range failures {
 		t.Error(err)
 	}
+}
+
+const committerTestTable = "ks.tbl"
+
+var errBatchRejected = errors.New("batch rejected")
+
+func committerTestPartitionKeys() typedef.Columns {
+	return typedef.Columns{
+		{Name: "pk0", Type: typedef.TypeText},
+		{Name: "pk1", Type: typedef.TypeInt},
+	}
+}
+
+type committedRow struct {
+	insert string
+	idx    int
+}
+
+type recorderAtExecTime struct {
+	pkLen           int
+	rows            []committedRow
+	incoherenceErrs []error
+	mu              sync.Mutex
+}
+
+func newRecorderAtExecTime(pkLen int) *recorderAtExecTime {
+	return &recorderAtExecTime{pkLen: pkLen}
+}
+
+func (r *recorderAtExecTime) record(insertStmt string, args []any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if want := r.pkLen + len(additionalColumnsArr); len(args) != want {
+		r.incoherenceErrs = append(r.incoherenceErrs, fmt.Errorf("bound %d args, want %d", len(args), want))
+
+		return
+	}
+
+	geminiStmt, ok := args[r.pkLen+3].(string)
+	if !ok {
+		r.incoherenceErrs = append(
+			r.incoherenceErrs,
+			fmt.Errorf("statement column has type %T, want string", args[r.pkLen+3]),
+		)
+
+		return
+	}
+
+	var idx int
+	if _, err := fmt.Sscanf(geminiStmt, "UPDATE ks.tbl SET c%d=?", &idx); err != nil {
+		r.incoherenceErrs = append(r.incoherenceErrs, fmt.Errorf("unparsable statement %q: %w", geminiStmt, err))
+
+		return
+	}
+
+	if err := checkCoherent(args, r.pkLen, idx); err != nil {
+		r.incoherenceErrs = append(r.incoherenceErrs, err)
+
+		return
+	}
+
+	r.rows = append(r.rows, committedRow{insert: insertStmt, idx: idx})
+}
+
+func (r *recorderAtExecTime) addBatch(_ context.Context, batch *gocql.Batch) error {
+	for _, entry := range batch.Entries {
+		r.record(entry.Stmt, entry.Args)
+	}
+
+	return nil
+}
+
+func (r *recorderAtExecTime) addQuery(_ context.Context, stmt string, args ...any) error {
+	r.record(stmt, args)
+
+	return nil
+}
+
+func (r *recorderAtExecTime) result(tb testing.TB) []committedRow {
+	tb.Helper()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, err := range r.incoherenceErrs {
+		tb.Error(err)
+	}
+
+	return append([]committedRow(nil), r.rows...)
+}
+
+func newCommitterLogger(tb testing.TB, ch <-chan stmtlogger.Item) (*Logger, *recorderAtExecTime) {
+	tb.Helper()
+
+	pks := committerTestPartitionKeys()
+	cql := makeTestCQL(pks)
+	cql.insertStmt = "INSERT INTO ks_logs.tbl(pk0,pk1," + additionalColumns + ") VALUES (?,?,?,?,?,?,?,?,?,?,?,?)"
+
+	committed := newRecorderAtExecTime(pks.LenValues())
+
+	return &Logger{
+		logger:     zap.NewNop(),
+		channel:    ch,
+		statements: map[string]*cqlStatements{committerTestTable: cql},
+		makeBatchHook: func(context.Context) *gocql.Batch {
+			return &gocql.Batch{}
+		},
+		execBatchHook: committed.addBatch,
+	}, committed
+}
+
+func committerItem(idx int) stmtlogger.Item {
+	it := distinctItem(idx)
+	it.Table = committerTestTable
+
+	return it
+}
+
+func runCommitter(tb testing.TB, logger *Logger, ch chan stmtlogger.Item, items []stmtlogger.Item) {
+	tb.Helper()
+
+	logger.wg.Add(1)
+
+	go logger.insertWorker()
+
+	for _, it := range items {
+		ch <- it
+	}
+
+	close(ch)
+	logger.wg.Wait()
+}
+
+func requireEachItemOnce(tb testing.TB, rows []committedRow, want int) {
+	tb.Helper()
+
+	seen := make(map[int]bool, len(rows))
+
+	for _, row := range rows {
+		require.True(tb, strings.HasPrefix(row.insert, "INSERT INTO ks_logs.tbl"))
+		require.False(tb, seen[row.idx], "item %d written twice", row.idx)
+		seen[row.idx] = true
+	}
+
+	require.Len(tb, seen, want)
+}
+
+func TestInsertWorker_BatchEntriesStayPaired(t *testing.T) {
+	t.Parallel()
+
+	const items = 4000
+
+	ch := make(chan stmtlogger.Item, 64)
+	logger, committed := newCommitterLogger(t, ch)
+
+	queued := make([]stmtlogger.Item, items)
+	for i := range queued {
+		queued[i] = committerItem(i)
+	}
+
+	runCommitter(t, logger, ch, queued)
+
+	rows := committed.result(t)
+	require.Len(t, rows, items)
+	requireEachItemOnce(t, rows, items)
+}
+
+func TestInsertWorker_DroppedItemsDoNotShiftPairing(t *testing.T) {
+	t.Parallel()
+
+	const items = 3000
+
+	ch := make(chan stmtlogger.Item, 64)
+	logger, committed := newCommitterLogger(t, ch)
+
+	queued := make([]stmtlogger.Item, 0, items)
+	kept := 0
+
+	for i := range items {
+		it := committerItem(i)
+
+		switch i % 3 {
+		case 1:
+			it.StatementType = typedef.SelectStatementType
+		case 2:
+			it.Table = "ks.unknown"
+		default:
+			kept++
+		}
+
+		queued = append(queued, it)
+	}
+
+	runCommitter(t, logger, ch, queued)
+
+	rows := committed.result(t)
+	require.Len(t, rows, kept)
+	requireEachItemOnce(t, rows, kept)
+
+	for _, row := range rows {
+		require.Zero(t, row.idx%3)
+	}
+}
+
+func TestInsertWorker_FallbackRowsMatchTheirStatements(t *testing.T) {
+	t.Parallel()
+
+	const items = 600
+
+	ch := make(chan stmtlogger.Item, 64)
+	logger, committed := newCommitterLogger(t, ch)
+
+	fallback := newRecorderAtExecTime(committerTestPartitionKeys().LenValues())
+	logger.execBatchHook = func(context.Context, *gocql.Batch) error {
+		return errBatchRejected
+	}
+	logger.execQueryHook = fallback.addQuery
+
+	queued := make([]stmtlogger.Item, items)
+	for i := range queued {
+		queued[i] = committerItem(i)
+	}
+
+	runCommitter(t, logger, ch, queued)
+
+	require.Empty(t, committed.result(t))
+
+	rows := fallback.result(t)
+	require.Len(t, rows, items)
+	requireEachItemOnce(t, rows, items)
 }

--- a/pkg/stmtlogger/scylla/scylla_unit_test.go
+++ b/pkg/stmtlogger/scylla/scylla_unit_test.go
@@ -990,6 +990,6 @@ func BenchmarkLine_Marshal(b *testing.B) {
 
 	b.ResetTimer()
 	for range b.N {
-		_ = utils.MarshalJSON(line)
+		_ = utils.MarshalJSONUnchecked(line)
 	}
 }

--- a/pkg/store/compare.go
+++ b/pkg/store/compare.go
@@ -198,7 +198,7 @@ func rowsToKeyStrings(table *typedef.Table, rows []Row) []string {
 
 func rowKeyString(table *typedef.Table, row Row) string {
 	if table == nil {
-		bytes := utils.MarshalJSON(row)
+		bytes := utils.MarshalJSONUnchecked(row)
 		return string(bytes)
 	}
 

--- a/pkg/store/cqlstore.go
+++ b/pkg/store/cqlstore.go
@@ -183,7 +183,7 @@ type MutationStoreError struct {
 }
 
 func (e MutationStoreError) Error() string {
-	data := utils.MarshalJSON(e.PartitionKeys)
+	data := utils.MarshalJSONUnchecked(e.PartitionKeys)
 
 	return "mutation error: " + e.Inner.Error() + ", partition keys: " + utils.UnsafeString(data)
 }

--- a/pkg/store/new_close_test.go
+++ b/pkg/store/new_close_test.go
@@ -88,7 +88,7 @@ func TestNew_BasicConfiguration(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	errorList := joberror.NewErrorList(10)
+	errorList := joberror.NewListError(10)
 
 	store, err := New(
 		keyspace,
@@ -153,7 +153,7 @@ func TestNew_WithoutOracleCluster(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	errorList := joberror.NewErrorList(10)
+	errorList := joberror.NewListError(10)
 
 	store, err := New(
 		keyspace,
@@ -221,7 +221,7 @@ func TestNew_DefaultConfiguration(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	errorList := joberror.NewErrorList(10)
+	errorList := joberror.NewListError(10)
 
 	store, err := New(
 		keyspace,
@@ -284,7 +284,7 @@ func TestNew_InvalidTestCluster(t *testing.T) {
 	}
 
 	logger := zap.NewNop()
-	errorList := joberror.NewErrorList(10)
+	errorList := joberror.NewListError(10)
 
 	store, err := New(
 		keyspace,

--- a/pkg/store/observers.go
+++ b/pkg/store/observers.go
@@ -227,14 +227,14 @@ func (c *ClusterObserver) ObserveBatch(ctx context.Context, batch gocql.Observed
 }
 
 func (c *ClusterObserver) ObserveQuery(ctx context.Context, query gocql.ObservedQuery) {
-	c.observeQuery(ctx, query, query.Attempt)
+	c.observeQuery(ctx, query, gocql.AttemptMetrics{}, false)
 }
 
 func (c *ClusterObserver) ObserveQueryWithAttemptMetrics(
 	ctx context.Context,
 	query gocql.ObservedQueryWithAttemptMetrics,
 ) {
-	c.observeQuery(ctx, query.ObservedQuery, hostAttempts(query.AttemptMetrics, query.Host))
+	c.observeQuery(ctx, query.ObservedQuery, query.AttemptMetrics, true)
 }
 
 func hostAttempts(metrics gocql.AttemptMetrics, host *gocql.HostInfo) int {
@@ -256,7 +256,12 @@ func hostAttempts(metrics gocql.AttemptMetrics, host *gocql.HostInfo) int {
 	return attempts
 }
 
-func (c *ClusterObserver) observeQuery(ctx context.Context, query gocql.ObservedQuery, attempts int) {
+func (c *ClusterObserver) observeQuery(
+	ctx context.Context,
+	query gocql.ObservedQuery,
+	attemptMetrics gocql.AttemptMetrics,
+	perHostAttempts bool,
+) {
 	data := MustGetContextData(ctx)
 	if data == nil {
 		return
@@ -281,6 +286,11 @@ func (c *ClusterObserver) observeQuery(ctx context.Context, query gocql.Observed
 	duration := query.End.Sub(query.Start)
 
 	if c.logger != nil && !data.Statement.QueryType.IsSelect() {
+		attempts := query.Attempt
+		if perHostAttempts {
+			attempts = hostAttempts(attemptMetrics, query.Host)
+		}
+
 		c.logStatement(data.Statement, stmtlogger.Item{
 			Error:         mo.Right[error, string](errStr),
 			Statement:     query.Statement,

--- a/pkg/tableopts/options.go
+++ b/pkg/tableopts/options.go
@@ -42,7 +42,7 @@ type MapOption struct {
 }
 
 func (o *MapOption) ToCQL() string {
-	b := utils.MarshalJSON(o.val)
+	b := utils.MarshalJSONUnchecked(o.val)
 	return o.key + " = " + strings.ReplaceAll(string(b), "\"", "'")
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -196,7 +196,7 @@ func Sizeof(v any) uint64 {
 	}
 }
 
-func MarshalJSON(v any) []byte {
+func MarshalJSONUnchecked(v any) []byte {
 	data, err := json.Marshal(v)
 	if err != nil {
 		return marshalFailure(err)
@@ -205,7 +205,7 @@ func MarshalJSON(v any) []byte {
 	return data
 }
 
-func MarshalJSONIndent(v any, prefix, indent string) []byte {
+func MarshalJSONIndentUnchecked(v any, prefix, indent string) []byte {
 	data, err := json.MarshalIndent(v, prefix, indent)
 	if err != nil {
 		return marshalFailure(err)


### PR DESCRIPTION
The `--replication-strategy` flag defaults to `network`, and
`replication.NewNetworkTopologyStrategy()` emitted a literal `datacenter1` key,
so every run against a cluster with another datacenter name failed at `CREATE
KEYSPACE`. In `pkg/statements/insert.go`, `convertForJSON` answered
`forcetypeassert` by returning the unconverted value. `TypeTime` then wrote a
zero time, because the generator produces a `time.Duration` and the converter
wanted an `int64`, and a tuple partition key wrote its type names because
`InsertJSON` walked `TupleType.ValueTypes` instead of the partition key values.
Gemini sent the same malformed payload to both clusters, so the comparison
stayed green and the corruption never surfaced.

This drops the datacenter key and makes a wrong type panic with the concrete
and the wanted type. It also covers the `_logs` committer, where
`gocql.Batch.Query` keeps the caller's args slice rather than copying it, so
every batch entry aliases the reused `held[idx]` buffer and the rows stay
correct only because the batch executes before that slot is rebound.
`insertWorker` had no test at all. Beyond that, `hostAttempts` no longer walks
the attempt list on the SELECT path, and `utils.MarshalJSON` becomes
`MarshalJSONUnchecked` so a future caller that needs the error does not reach
for it.