### PR TITLE
chore: narrow the lint exclusions and record the cluster constraints

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,3 +49,4 @@ jobs:
         name: Linting
         with:
           install-mode: goinstall
+          version: v2.13.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -145,13 +145,17 @@ linters:
       - legacy
       - std-error-handling
     rules:
-      - path: 'pkg/(cmd|status|benchmarks)/'
+      - path: 'pkg/(cmd/(root|benchmark)|status/status|benchmarks/results)\.go$'
         linters:
           - forbidigo
       - path: _test\.go$
         linters:
           - govet
-        text: '(fieldalignment|shadow)'
+        text: fieldalignment
+      - path: 'pkg/stmtlogger/scylla/.*_test\.go$'
+        linters:
+          - govet
+        text: shadow
       - path: _test\.go$
         linters:
           - lll

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,26 +21,26 @@ a system under test (SUT) and a test oracle.
 - **Database**: Scylla/Cassandra using CQL protocol
 - **Testing**: Randomized testing with statistical distributions
 
-## Go instructions (1.26, 1.27)
+## Go instructions (Go 1.27)
 
-1. Always use `for range` instead of `for` with `i++` when iterating, this is the new syntax from Go 1.25
+1. Always use `for range` instead of `for` with `i++` when iterating, this is the syntax added in Go 1.22
    Example: `for i := 0; i < 10; i++` should be replaced with `for i := range 10`. If the `i` is not needed it can be
    omitted.
    This is also true when using some integer variable as a counter. `for i := 0; i < VARIABLE; i++` can be replaced with
    `for i := range VARIABLE`, also `i` can be omitted.
-2. Always assume `go` **1.27**. Prefer `go` commands that work with Go 1.27.
+2. Go **1.27** is the default. Assume it, and prefer `go` commands that work with Go 1.27.
 3. Keep `go.mod` `go 1.27`. Do **not** add a `toolchain` line when updating the `go` line (Go 1.27 no longer auto-adds
    it).
 4. Use the new `go.mod` **`ignore`** directive to exclude non-packages (e.g., examples, scratch) from `./...`
 5. Prefer standard library first; avoid third-party deps unless asked.
-6. Slice stack-allocation opportunities (new in 1.25) and avoid unsafe pointer aliasing.
+6. Slice stack-allocation opportunities (added in Go 1.25) and avoid unsafe pointer aliasing.
 7. Use testing/synctest for flaky/racy tests.
 8. Consider the container-aware GOMAXPROCS defaults when benchmarking.
 9. **DWARF 5** debug info by default
 10. Add a `synctest` based test that removes `time.Sleep` and waits deterministically.
 11. Use `go test -race` to detect data races.
-12. Always use in tests for context `t.Context()` and for benchmarking `b.Context()`, there are new go 1.24 function,
-    and they better and avoid linting errors.
+12. In tests use `t.Context()` for context, and `b.Context()` in benchmarks. Both were added in Go 1.24 and they
+    avoid linting errors.
 13. Use `t.Cleanup()` to register cleanup functions in tests instead of `defer` to ensure proper execution order.
 14. Use `t.Parallel()` to run tests in parallel.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,38 @@ Any difference indicates a bug in the SUT.
    After configurable delays, they are re-validated (expecting zero rows on both clusters).
 9. **Error budget**: When max errors reached, workers stop gracefully via `stop.Flag`.
 
+## Cluster Requirements
+
+Gemini writes to real ScyllaDB or Cassandra nodes. Three constraints control keyspace creation.
+
+1. **ScyllaDB 2026 turns tablets on by default and rejects `SimpleStrategy`.** The server answers
+   "SimpleStrategy doesn't support tablet replication" and creates no keyspace. Use
+   `NetworkTopologyStrategy` in every default, test fixture and hardcoded `CREATE KEYSPACE`.
+2. **A replication default must not name a datacenter.** `replication.NewNetworkTopologyStrategy()`
+   emits `{'class':'NetworkTopologyStrategy','replication_factor':1}`. A literal datacenter key makes
+   `CREATE KEYSPACE` fail on every cluster with a different datacenter name. A user who needs a
+   datacenter passes it through `--replication-strategy`.
+3. **The oracle runs an older version than the system under test.** `pkg/testutils/scylladb.go` sets
+   `DefaultOracleVersion = "2026.1"` and `DefaultTestVersion = "2026.2"`. The oracle is the source of
+   truth, so it must be the version you already trust.
+
+## Cross-Cutting Invariants
+
+- **One store serves every table.** `pkg/services/workload.go` builds the store from
+  `schema.Tables[0]`. Per-table behavior must come from the statement's own query, never from the
+  store constructor arguments. `utils.KeyspaceTableFromQuery` does this for statement-log routing
+  and for asymmetric-write compensation.
+- **A compensating DELETE must reuse the original write timestamp.** Client-side timestamps are the
+  default. A DELETE in a different timestamp domain does not cancel the write it compensates.
+- **`_logs` statement/values pairing rests on an aliasing rule.** `gocql.Batch.Query` stores the
+  caller's args slice, it does not copy. The committer binds into `held[idx]` and reuses that buffer
+  only after the batch executed, so every row is coherent at the moment the driver reads it. Never
+  make batch execution asynchronous, and never rebind a `held` slot that a pending entry still
+  aliases. `pkg/stmtlogger/scylla/scylla_pairing_test.go` fails when either rule breaks.
+- **A failed validation is not proof of a SUT bug until the run is clean.** A timed-out mutation
+  leaves one cluster ahead of the other. Check the asymmetric-write metrics before you attribute a
+  difference to the system under test.
+
 ## Project Structure
 
 - `pkg/` -- all packages for the gemini project
@@ -72,26 +104,26 @@ Any difference indicates a bug in the SUT.
 - **Database**: Scylla/Cassandra using CQL protocol
 - **Testing**: Randomized testing with statistical distributions
 
-## Go Instructions (1.26, 1.27)
+## Go Instructions (Go 1.27)
 
-1. Always use `for range` instead of `for` with `i++` when iterating, this is the new syntax from Go 1.25
+1. Always use `for range` instead of `for` with `i++` when iterating, this is the syntax added in Go 1.22
    Example: `for i := 0; i < 10; i++` should be replaced with `for i := range 10`. If the `i` is not needed it can be
    omitted.
    This is also true when using some integer variable as a counter. `for i := 0; i < VARIABLE; i++` can be replaced with
    `for i := range VARIABLE`, also `i` can be omitted.
-2. Always assume `go` **1.27**. Prefer `go` commands that work with Go 1.27.
+2. Go **1.27** is the default. Assume it, and prefer `go` commands that work with Go 1.27.
 3. Keep `go.mod` `go 1.27`. Do **not** add a `toolchain` line when updating the `go` line (Go 1.27 no longer auto-adds
    it).
 4. Use the new `go.mod` **`ignore`** directive to exclude non-packages (e.g., examples, scratch) from `./...`
 5. Prefer standard library first; avoid third-party deps unless asked.
-6. Slice stack-allocation opportunities (new in 1.25) and avoid unsafe pointer aliasing.
+6. Slice stack-allocation opportunities (added in Go 1.25) and avoid unsafe pointer aliasing.
 7. Use testing/synctest for flaky/racy tests.
 8. Consider the container-aware GOMAXPROCS defaults when benchmarking.
 9. **DWARF 5** debug info by default
 10. Add a `synctest` based test that removes `time.Sleep` and waits deterministically.
 11. Use `go test -race` to detect data races.
-12. Always use in tests for context `t.Context()` and for benchmarking `b.Context()`, there are new go 1.24 function,
-    and they better and avoid linting errors.
+12. In tests use `t.Context()` for context, and `b.Context()` in benchmarks. Both were added in Go 1.24 and they
+    avoid linting errors.
 13. Use `t.Cleanup()` to register cleanup functions in tests instead of `defer` to ensure proper execution order.
 14. Use `t.Parallel()` to run tests in parallel.
 
@@ -144,6 +176,79 @@ Integration tests require two running ScyllaDB nodes (oracle + test).
 | `GEMINI_ORACLE_CLUSTER_IP` | IP of the oracle node | `192.168.100.2` |
 
 For cluster tests (3-node), use `docker/docker-compose-scylla-cluster.yml` instead.
+
+### Test Runtime
+
+Four packages start containers and take minutes, not seconds. Measured on an idle machine with a
+warm image cache:
+
+| Package | Typical time |
+|---|---|
+| `pkg/stmtlogger/scylla` | 4 min 30 s |
+| `pkg/store` | 3 min |
+| `pkg/typedef` | 3 min |
+| `pkg/services` | 2 min 30 s |
+
+Give the whole suite at least 10 minutes. `make test` already passes `-timeout 10m`. A run that
+appears to hang after two minutes is one of these packages, not a deadlock. Run one package when you
+only changed one package.
+
+## Make Targets
+
+| Target | Action |
+|---|---|
+| `make check` | `golangci-lint run` |
+| `make fix` | `golangci-lint run --fix` |
+| `make fmt` | `golangci-lint fmt` |
+| `make test` | Full suite with race detector, coverage and `gotestfmt` output |
+| `make setup` | Start the two-node Docker environment and build the debug binary |
+| `make scylla-setup` / `make scylla-shutdown` | Start or stop the two-node environment |
+| `make scylla-setup-cluster` | Start the three-node environment with monitoring |
+| `make integration-test` | Run gemini against the two nodes |
+| `make fieldalign` | Report struct field ordering |
+
+`make fieldalign-fix` rewrites every reported struct and drops the comments inside it. Read the diff
+before you keep it.
+
+## Lint Gates That Change Code
+
+`golangci-lint` runs more than 60 linters. Five of them push toward a weaker program if you satisfy
+them without thought.
+
+- **`forcetypeassert`** bans `v := x.(T)`. Do not answer it with `if v, ok := x.(T); ok` and a silent
+  fallthrough. Gemini generates its own values, so a failed assertion is a gemini bug, and a silent
+  fallthrough books that bug as a SUT failure. Panic with the concrete and the wanted type, as
+  `mustConvert` does in `pkg/statements/insert.go`.
+- **`errchkjson`** bans an unchecked `json.Marshal`. `String()`, `Error()` and `ToCQL()` cannot
+  return an error, so they call `utils.MarshalJSONUnchecked`, which puts the failure in the returned
+  JSON. Every other call site handles the error.
+- **`errname`** requires the `Error` suffix on an error type. This is why the list of job errors is
+  `joberror.ListError`.
+- **`testifylint`** rejects `assert.Equal` on floats. A test that pins an exact constant compares
+  with `!=` in plain Go. Do not weaken it to `InDelta`.
+- **`forbidigo`** bans `fmt.Print*`. Four files print by design and are named in `.golangci.yml`.
+  Everything else logs through `zap`.
+
+`gofumpt` uses `extra.group-params`. `extra-rules` is the deprecated spelling of the same rule.
+
+## Documentation Map
+
+| File | Content |
+|---|---|
+| `docs/architecture.md` | Component diagram and data flow |
+| `docs/getting-started.md` | First run |
+| `docs/cli-arguments.md`, `docs/cmdhelp.md` | Every flag |
+| `docs/schema.md` | Schema JSON format and replication examples |
+| `docs/partitions.md` | Partition pool and distributions |
+| `docs/statement-logger.md` | Statement log tables and files |
+| `docs/statement-ratio.md` | Mutation and validation ratio control |
+| `docs/targeted-deletions.md` | Delete tracking and re-validation |
+| `docs/metrics.md` | Prometheus metrics |
+| `docs/investigation.md`, `docs/troubleshooting.md` | Triage of a failed run |
+| `docs/benchmarks.md`, `docs/development.md`, `docs/release-process.md` | Contributor workflow |
+| `docs/quickref.md` | Command cheat sheet |
+
+Keep `docs/` current. Update the architecture diagrams when the flow changes.
 
 ---
 

--- a/pkg/metrics/channel_metrics.go
+++ b/pkg/metrics/channel_metrics.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package metrics
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package metrics
 

--- a/pkg/partitions/deleted_backpressure_test.go
+++ b/pkg/partitions/deleted_backpressure_test.go
@@ -163,7 +163,7 @@ func TestHeapMemoryManagement(t *testing.T) {
 	t.Run("heap_grows_as_needed", func(t *testing.T) {
 		t.Parallel()
 
-		buckets := []time.Duration{100 * time.Millisecond}
+		buckets := []time.Duration{1 * time.Hour}
 		d := newDeleted(t.Context(), buckets, 0)
 		defer d.Close()
 
@@ -201,7 +201,7 @@ func TestDeleteEdgeCases(t *testing.T) {
 
 	t.Run("empty_heap_works", func(t *testing.T) {
 		t.Parallel()
-		buckets := []time.Duration{100 * time.Millisecond}
+		buckets := []time.Duration{1 * time.Hour}
 		d := newDeleted(t.Context(), buckets, 0)
 		defer d.Close()
 

--- a/pkg/partitions/rowtracker_test.go
+++ b/pkg/partitions/rowtracker_test.go
@@ -253,9 +253,17 @@ func TestFillZoneConstants(t *testing.T) {
 	assert.Less(t, FillZoneSkip, 1.0)
 
 	// Verify expected values match documented thresholds
-	assert.InDelta(t, 0.30, FillZoneAlwaysPush, 1e-9)
-	assert.InDelta(t, 0.70, FillZoneSampled, 1e-9)
-	assert.InDelta(t, 0.90, FillZoneSkip, 1e-9)
+	if FillZoneAlwaysPush != 0.30 {
+		t.Errorf("FillZoneAlwaysPush = %v, want 0.30", FillZoneAlwaysPush)
+	}
+
+	if FillZoneSampled != 0.70 {
+		t.Errorf("FillZoneSampled = %v, want 0.70", FillZoneSampled)
+	}
+
+	if FillZoneSkip != 0.90 {
+		t.Errorf("FillZoneSkip = %v, want 0.90", FillZoneSkip)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/stmtlogger/scylla/scylla_regression_test.go
+++ b/pkg/stmtlogger/scylla/scylla_regression_test.go
@@ -35,8 +35,6 @@ import (
 // per line, with the job error's own query, message and partition keys, and the
 // streamed rows verbatim. Rows are written straight from the CQL iterator now,
 // so a malformed separator would corrupt the file for every later reader.
-//
-
 func TestStatementSink_JSONLRegression(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -535,8 +535,6 @@ func (ds delegatingStore) executeParallelMutations(
 }
 
 // waitForMutationResults waits for mutation results and updates the result struct
-//
-
 func (ds delegatingStore) waitForMutationResults(ctx context.Context, ch chan mutationChanRes, result *mutationResult, expectTest, expectOracle bool, expected int) {
 	received := 0
 	for received < expected {

--- a/pkg/store/validation_bench_test.go
+++ b/pkg/store/validation_bench_test.go
@@ -734,7 +734,6 @@ func BenchmarkZipAndCompare(b *testing.B) {
 }
 
 // ── BenchmarkComparisonResult_ToError ────────────────────────────────────────
-// ToError builds multierr error values; benchmarks the error-rendering path.
 
 func BenchmarkComparisonResult_ToError(b *testing.B) {
 	table := makeScalarTable(2)

--- a/pkg/utils/backoff.go
+++ b/pkg/utils/backoff.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package utils
 

--- a/pkg/utils/backoff_test.go
+++ b/pkg/utils/backoff_test.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package utils
 

--- a/pkg/utils/fs.go
+++ b/pkg/utils/fs.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package utils
 

--- a/pkg/utils/timer_pool.go
+++ b/pkg/utils/timer_pool.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package utils
 


### PR DESCRIPTION
The `forbidigo` exclusion covered all of `pkg/cmd`, `pkg/status` and
`pkg/benchmarks`, and the `govet shadow` exclusion covered every `_test.go` in
the repository. A new `fmt.Print` in `pkg/cmd`, or a shadowed `err` in any
test, passed the gate. The golangci-lint action ran unpinned, so a new
upstream release changed the result of a run that touched no code. The heap
growth tests in `pkg/partitions` read `Len()` while the drain goroutine emptied
the heap, which passed locally and failed in CI.

The `forbidigo` exclusion now names the four files that print by design, and
the shadow exclusion names the one package that needs it. CI pins
golangci-lint to v2.13.2. The heap growth tests use a bucket that outlives the
assertion. `CLAUDE.md` records the three cluster constraints that ScyllaDB 2026
imposes, the cross-cutting invariants, the five lint gates that push toward a
weaker program, and the runtime of the four packages that start containers.